### PR TITLE
feat: v0.2.0 — multilingual docs, keybinding fixes, settings redesign

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,7 @@ dependencies = [
 
 [[package]]
 name = "ezpn"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ezpn"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.70"
 autobins = false

--- a/README.md
+++ b/README.md
@@ -4,11 +4,13 @@
 
 # ezpn
 
-A terminal pane splitter. Click to select. Drag to resize. No config needed.
+Split your terminal in one command. Click, drag, done.
 
 [![License](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
-[![Crate](https://img.shields.io/badge/crates.io-v0.1.0-orange)](https://crates.io/crates/ezpn)
+[![Crate](https://img.shields.io/badge/crates.io-v0.2.0-orange)](https://crates.io/crates/ezpn)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-lightgrey)]()
+
+**English** | [한국어](docs/README.ko.md) | [日本語](docs/README.ja.md) | [中文](docs/README.zh.md) | [Español](docs/README.es.md) | [Français](docs/README.fr.md)
 
 ## Install
 

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -1,0 +1,79 @@
+<p align="center">
+  <img src="../assets/hero.png" width="720" alt="ezpn en accion">
+</p>
+
+# ezpn
+
+Divide tu terminal con un solo comando. Clic, arrastra, listo.
+
+[![License](https://img.shields.io/badge/license-MIT-blue)](../LICENSE)
+[![Crate](https://img.shields.io/badge/crates.io-v0.2.0-orange)](https://crates.io/crates/ezpn)
+[![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-lightgrey)]()
+
+[English](../README.md) | [한국어](README.ko.md) | [日本語](README.ja.md) | [中文](README.zh.md) | **Español** | [Français](README.fr.md)
+
+## Instalacion
+
+```bash
+cargo install ezpn
+```
+
+## Uso
+
+```bash
+ezpn              # 2 paneles lado a lado
+ezpn 4            # 4 paneles horizontales
+ezpn 3 -d v       # 3 paneles verticales
+ezpn 2 3          # cuadricula 2x3
+ezpn --layout '7:3/1:1'   # diseño con proporciones
+ezpn -e 'make watch' -e 'npm dev'   # comando por panel
+```
+
+## Controles
+
+**Raton:** Clic para seleccionar / `x` para cerrar / Arrastrar borde para redimensionar / Scroll
+
+**Teclado:**
+
+| Tecla | Accion |
+|---|---|
+| `Ctrl+D` | Dividir izquierda \| derecha |
+| `Ctrl+E` | Dividir arriba / abajo |
+| `Ctrl+N` | Panel siguiente |
+| `Ctrl+G` | Panel de ajustes |
+| `Ctrl+W` | Salir |
+
+**Teclas compatibles con tmux (`Ctrl+B` seguido de):**
+
+| Tecla | Accion |
+|---|---|
+| `%` | Dividir izquierda \| derecha |
+| `"` | Dividir arriba / abajo |
+| `o` | Panel siguiente |
+| `Arrow` | Navegacion direccional |
+| `x` | Cerrar panel |
+| `[` | Modo scroll (j/k/g/G, q para salir) |
+| `d` | Salir (con confirmacion) |
+
+## Caracteristicas
+
+- **Diseños flexibles** — Cuadricula, proporciones, division libre, redimensionar arrastrando
+- **Comando por panel** — `-e` para lanzar comandos diferentes
+- **Botones en barra de titulo** — `[━] [┃] [×]` clic para dividir/cerrar
+- **Teclas tmux** — `Ctrl+B` seguido de teclas tmux estandar
+- **Control IPC** — `ezpn-ctl` para automatizacion
+- **Snapshots de espacio de trabajo** — `ezpn-ctl save/load`
+
+## Comparacion
+
+|  | tmux | Zellij | ezpn |
+|---|---|---|---|
+| Config | `.tmux.conf` | Archivos KDL | Flags CLI |
+| Dividir | `Ctrl+B %` | Cambio de modo | `Ctrl+D` / clic |
+| Detach | Si | Si | No |
+
+Usa tmux/Zellij si necesitas persistencia de sesion. Usa ezpn si solo quieres dividir terminales.
+
+## Licencia
+
+[MIT](../LICENSE)

--- a/docs/README.fr.md
+++ b/docs/README.fr.md
@@ -1,0 +1,79 @@
+<p align="center">
+  <img src="../assets/hero.png" width="720" alt="ezpn en action">
+</p>
+
+# ezpn
+
+Divisez votre terminal en une commande. Cliquez, glissez, c'est fait.
+
+[![License](https://img.shields.io/badge/license-MIT-blue)](../LICENSE)
+[![Crate](https://img.shields.io/badge/crates.io-v0.2.0-orange)](https://crates.io/crates/ezpn)
+[![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-lightgrey)]()
+
+[English](../README.md) | [한국어](README.ko.md) | [日本語](README.ja.md) | [中文](README.zh.md) | [Español](README.es.md) | **Français**
+
+## Installation
+
+```bash
+cargo install ezpn
+```
+
+## Utilisation
+
+```bash
+ezpn              # 2 panneaux cote a cote
+ezpn 4            # 4 panneaux horizontaux
+ezpn 3 -d v       # 3 panneaux verticaux
+ezpn 2 3          # grille 2x3
+ezpn --layout '7:3/1:1'   # disposition avec ratios
+ezpn -e 'make watch' -e 'npm dev'   # commande par panneau
+```
+
+## Controles
+
+**Souris :** Cliquez pour selectionner / `x` pour fermer / Glissez le bord pour redimensionner / Molette
+
+**Clavier :**
+
+| Touche | Action |
+|---|---|
+| `Ctrl+D` | Diviser gauche \| droite |
+| `Ctrl+E` | Diviser haut / bas |
+| `Ctrl+N` | Panneau suivant |
+| `Ctrl+G` | Panneau de reglages |
+| `Ctrl+W` | Quitter |
+
+**Touches compatibles tmux (`Ctrl+B` puis) :**
+
+| Touche | Action |
+|---|---|
+| `%` | Diviser gauche \| droite |
+| `"` | Diviser haut / bas |
+| `o` | Panneau suivant |
+| `Arrow` | Navigation directionnelle |
+| `x` | Fermer le panneau |
+| `[` | Mode defilement (j/k/g/G, q pour quitter) |
+| `d` | Quitter (avec confirmation) |
+
+## Fonctionnalites
+
+- **Dispositions flexibles** — Grille, ratios, division libre, redimensionnement par glissement
+- **Commande par panneau** — `-e` pour lancer des commandes differentes
+- **Boutons de barre de titre** — `[━] [┃] [×]` cliquez pour diviser/fermer
+- **Touches tmux** — `Ctrl+B` suivi des touches tmux standard
+- **Controle IPC** — `ezpn-ctl` pour l'automatisation
+- **Instantanes d'espace de travail** — `ezpn-ctl save/load`
+
+## Comparaison
+
+|  | tmux | Zellij | ezpn |
+|---|---|---|---|
+| Config | `.tmux.conf` | Fichiers KDL | Flags CLI |
+| Diviser | `Ctrl+B %` | Changement de mode | `Ctrl+D` / clic |
+| Detacher | Oui | Oui | Non |
+
+Utilisez tmux/Zellij pour la persistance de session. Utilisez ezpn pour diviser rapidement votre terminal.
+
+## Licence
+
+[MIT](../LICENSE)

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -1,0 +1,77 @@
+<p align="center">
+  <img src="../assets/hero.png" width="720" alt="ezpn デモ">
+</p>
+
+# ezpn
+
+コマンド一つでターミナルを分割。クリック、ドラッグ、完了。
+
+[![License](https://img.shields.io/badge/license-MIT-blue)](../LICENSE)
+[![Crate](https://img.shields.io/badge/crates.io-v0.2.0-orange)](https://crates.io/crates/ezpn)
+[![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-lightgrey)]()
+
+[English](../README.md) | [한국어](README.ko.md) | **日本語** | [中文](README.zh.md) | [Español](README.es.md) | [Français](README.fr.md)
+
+## インストール
+
+```bash
+cargo install ezpn
+```
+
+## 使い方
+
+```bash
+ezpn              # 2ペイン（横並び）
+ezpn 4            # 4ペイン（横方向）
+ezpn 3 -d v       # 3ペイン（縦方向）
+ezpn 2 3          # 2×3グリッド
+ezpn --layout '7:3/1:1'   # 比率指定レイアウト
+ezpn -e 'make watch' -e 'npm dev'   # ペインごとのコマンド
+```
+
+## 操作方法
+
+**マウス:** クリックで選択 / `×`で閉じる / ボーダーをドラッグでリサイズ / スクロール対応
+
+**キーボード:**
+
+| キー | 操作 |
+|---|---|
+| `Ctrl+D` | 左右分割 |
+| `Ctrl+E` | 上下分割 |
+| `Ctrl+N` | 次のペイン |
+| `Ctrl+G` | 設定パネル |
+| `Ctrl+W` | 終了 |
+
+**tmux互換キー (`Ctrl+B` の後):**
+
+| キー | 操作 |
+|---|---|
+| `%` | 左右分割 |
+| `"` | 上下分割 |
+| `o` | 次のペイン |
+| `Arrow` | 方向移動 |
+| `x` | ペインを閉じる |
+| `[` | スクロールモード (j/k/g/G、qで終了) |
+| `d` | 終了（確認あり） |
+
+## 主な機能
+
+- **自由なレイアウト** — グリッド、比率指定、個別分割、ドラッグリサイズ
+- **ペインごとのコマンド** — `-e`フラグで個別コマンド起動
+- **タイトルバーボタン** — `[━] [┃] [×]` クリックで分割・閉じる
+- **tmuxプリフィクスキー** — `Ctrl+B`の後にtmuxキーが使用可能
+- **IPC自動化** — `ezpn-ctl`による外部制御
+- **ワークスペースの保存・復元** — `ezpn-ctl save/load`
+
+## 比較
+
+|  | tmux | Zellij | ezpn |
+|---|---|---|---|
+| 設定 | `.tmux.conf` | KDLファイル | CLIフラグ |
+| 分割 | `Ctrl+B %` | モード切替 | `Ctrl+D` / クリック |
+| Detach | 可能 | 可能 | 不可 |
+
+## ライセンス
+
+[MIT](../LICENSE)

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -1,0 +1,92 @@
+<p align="center">
+  <img src="../assets/hero.png" width="720" alt="ezpn 실행 화면">
+</p>
+
+# ezpn
+
+명령어 하나로 터미널을 분할하세요. 클릭, 드래그, 끝.
+
+[![License](https://img.shields.io/badge/license-MIT-blue)](../LICENSE)
+[![Crate](https://img.shields.io/badge/crates.io-v0.2.0-orange)](https://crates.io/crates/ezpn)
+[![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-lightgrey)]()
+
+[English](../README.md) | **한국어** | [日本語](README.ja.md) | [中文](README.zh.md) | [Español](README.es.md) | [Français](README.fr.md)
+
+## 설치
+
+```bash
+cargo install ezpn
+```
+
+## 사용법
+
+```bash
+ezpn              # 2분할 (좌우)
+ezpn 4            # 4분할 (가로)
+ezpn 3 -d v       # 3분할 (세로)
+ezpn 2 3          # 2×3 그리드
+ezpn --layout '7:3/1:1'   # 비율 지정 레이아웃
+ezpn -e 'make watch' -e 'npm dev'   # 패널별 명령어
+```
+
+`-e/--exec`로 전달된 명령어는 `$SHELL -l -c`로 실행됩니다.
+
+## 조작법
+
+**마우스:**
+
+| 동작 | 효과 |
+|------|------|
+| 패널 클릭 | 포커스 |
+| `×` 클릭 | 패널 닫기 |
+| 보더 드래그 | 크기 조절 |
+| 스크롤 | 활성 패널 스크롤 |
+
+**키보드 (직접 단축키):**
+
+| 키 | 동작 |
+|---|---|
+| `Ctrl+D` | 좌우 분할 |
+| `Ctrl+E` | 상하 분할 |
+| `Ctrl+N` | 다음 패널 |
+| `Ctrl+G` | 설정 패널 (j/k로 이동) |
+| `Ctrl+W` | 종료 |
+
+**tmux 호환 키 (`Ctrl+B` 후):**
+
+| 키 | 동작 |
+|---|---|
+| `%` | 좌우 분할 |
+| `"` | 상하 분할 |
+| `o` | 다음 패널 |
+| `Arrow` | 방향 이동 |
+| `x` | 패널 닫기 |
+| `[` | 스크롤 모드 (j/k/g/G, q로 나가기) |
+| `d` | 종료 (확인 대화상자) |
+
+## 주요 기능
+
+- **자유 레이아웃** — 그리드, 비율 지정, 개별 분할, 드래그 리사이즈
+- **패널별 명령어** — `-e 'htop' -e 'npm dev' -e 'tail -f log'`
+- **타이틀 바 버튼** — `[━] [┃] [×]` 클릭으로 분할/닫기
+- **tmux 프리픽스 키** — `Ctrl+B` 후 tmux 키 사용 가능
+- **스크롤 모드** — `Ctrl+B [` → vim 키로 히스토리 탐색
+- **설정 패널** — `Ctrl+G` → 어두운 모달, vim 키 네비게이션
+- **IPC 원격 제어** — `ezpn-ctl`로 자동화
+- **워크스페이스 저장/복원** — `ezpn-ctl save/load`
+- **중첩 방지** — `$EZPN` 환경변수로 자동 차단
+
+## 비교
+
+|  | tmux | Zellij | ezpn |
+|---|---|---|---|
+| 설정 | `.tmux.conf` | KDL 파일 | CLI 플래그 |
+| 분할 | `Ctrl+B %` | 모드 전환 | `Ctrl+D` / 클릭 |
+| 크기 조절 | `:resize-pane` | 리사이즈 모드 | 드래그 |
+| Detach | 가능 | 가능 | 불가 |
+
+세션 유지가 필요하면 tmux/Zellij. 빠르게 화면만 분할하고 싶으면 ezpn.
+
+## 라이선스
+
+[MIT](../LICENSE)

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -1,0 +1,79 @@
+<p align="center">
+  <img src="../assets/hero.png" width="720" alt="ezpn 演示">
+</p>
+
+# ezpn
+
+一条命令分割终端。点击、拖拽，搞定。
+
+[![License](https://img.shields.io/badge/license-MIT-blue)](../LICENSE)
+[![Crate](https://img.shields.io/badge/crates.io-v0.2.0-orange)](https://crates.io/crates/ezpn)
+[![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-lightgrey)]()
+
+[English](../README.md) | [한국어](README.ko.md) | [日本語](README.ja.md) | **中文** | [Español](README.es.md) | [Français](README.fr.md)
+
+## 安装
+
+```bash
+cargo install ezpn
+```
+
+## 用法
+
+```bash
+ezpn              # 左右两个面板
+ezpn 4            # 4个水平面板
+ezpn 3 -d v       # 3个垂直面板
+ezpn 2 3          # 2×3 网格
+ezpn --layout '7:3/1:1'   # 比例布局
+ezpn -e 'make watch' -e 'npm dev'   # 每个面板运行不同命令
+```
+
+## 操作
+
+**鼠标：** 点击选择 / `×`关闭 / 拖拽边框调整大小 / 滚轮滚动
+
+**键盘：**
+
+| 按键 | 操作 |
+|---|---|
+| `Ctrl+D` | 左右分割 |
+| `Ctrl+E` | 上下分割 |
+| `Ctrl+N` | 下一个面板 |
+| `Ctrl+G` | 设置面板 |
+| `Ctrl+W` | 退出 |
+
+**tmux 兼容键（`Ctrl+B` 之后）：**
+
+| 按键 | 操作 |
+|---|---|
+| `%` | 左右分割 |
+| `"` | 上下分割 |
+| `o` | 下一个面板 |
+| `Arrow` | 方向导航 |
+| `x` | 关闭面板 |
+| `[` | 滚动模式（j/k/g/G，q退出） |
+| `d` | 退出（有确认提示） |
+
+## 主要功能
+
+- **灵活布局** — 网格、比例指定、自由分割、拖拽调整
+- **面板独立命令** — `-e`标志为每个面板指定命令
+- **标题栏按钮** — `[━] [┃] [×]` 点击即可分割或关闭
+- **tmux 前缀键** — `Ctrl+B` 后使用 tmux 按键
+- **IPC 自动化** — `ezpn-ctl` 外部控制
+- **工作区快照** — `ezpn-ctl save/load` 保存和恢复
+
+## 对比
+
+|  | tmux | Zellij | ezpn |
+|---|---|---|---|
+| 配置 | `.tmux.conf` | KDL文件 | CLI参数 |
+| 分割 | `Ctrl+B %` | 模式切换 | `Ctrl+D` / 点击 |
+| 分离 | 支持 | 支持 | 不支持 |
+
+需要会话持久化用 tmux/Zellij，只想快速分屏用 ezpn。
+
+## 许可证
+
+[MIT](../LICENSE)

--- a/src/render.rs
+++ b/src/render.rs
@@ -674,11 +674,11 @@ pub fn draw_status_bar(
         SetBackgroundColor(STATUS_BG)
     )?;
     let hints = [
-        "Ctrl+D/E:split",
-        "Ctrl+N:next",
-        "F2:equalize",
-        "Ctrl+G:settings",
-        "Ctrl+W:quit",
+        "Ctrl+D/E split",
+        "Ctrl+N next",
+        "Ctrl+B prefix",
+        "Ctrl+G settings",
+        "Ctrl+W quit",
     ];
     let mut right_str = String::new();
     for hint in hints.iter() {


### PR DESCRIPTION
## Summary

- Multilingual README: EN, KO, JA, ZH, ES, FR
- macOS-compatible keybindings (Ctrl+W quit, Ctrl+N next)
- Ctrl+B prefix mode (tmux-compatible)
- Settings modal redesigned (52x20, dark, vim keys)
- Title bar split/close buttons
- Scroll mode with vim keys
- Frame cap + modal render optimization

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (22 pass)
- [x] `cargo build --release`
- [ ] Manual: Ctrl+W quits
- [ ] Manual: Ctrl+N cycles panes
- [ ] Manual: Ctrl+B % splits
- [ ] Manual: Ctrl+G opens settings, j/k navigates
- [ ] Manual: Click [━] [┃] [×] buttons work

Generated with [Claude Code](https://claude.ai/claude-code)