### PR TITLE
chore: release v0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,7 +91,7 @@ dependencies = [
 
 [[package]]
 name = "ezpn"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ezpn"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 rust-version = "1.82"
 autobins = false

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Dead simple terminal pane splitting with session persistence. Think tmux, but instant.
 
 [![License](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
-[![Crate](https://img.shields.io/badge/crates.io-v0.4.0-orange)](https://crates.io/crates/ezpn)
+[![Crate](https://img.shields.io/badge/crates.io-v0.4.1-orange)](https://crates.io/crates/ezpn)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-lightgrey)]()
 
 **English** | [한국어](docs/README.ko.md) | [日本語](docs/README.ja.md) | [中文](docs/README.zh.md) | [Español](docs/README.es.md) | [Français](docs/README.fr.md)


### PR DESCRIPTION
## v0.4.1 — Performance, Copy Mode, Input Fixes

### Performance
- **0.14ms** key→frame RTT (was 3ms) — wake-channel event loop
- **2.6MB** memory (vs tmux 6MB)
- **785K** keys/sec throughput
- Reusable 64KB render buffer, batched stdout flush, PTY drain limit

### New Features
- **Copy mode** (`Ctrl+B [`): vi navigation (hjkl/w/b/0/$), visual selection (v/V), yank (y), search (/ ? n N)
- **Borderless mode** (`-b none`): 10% more screen space
- **Command palette** (`Ctrl+B :`): 11 commands with tmux aliases
- **Tab rename**: `Ctrl+B ,` with pre-fill + double-click tab bar
- **Configurable prefix**: `prefix = a` in config.toml
- **Session rename**: `ezpn rename old new`
- **Close confirmations**: pane (y/n), tab (y/n), session (y/n)

### Input Fixes
- Ctrl+]/^/Space correct bytes (vim compat)
- Alt+Backspace → ESC DEL (shell word delete)
- F-key modifiers forwarded
- OSC 52 passthrough, bracketed paste, focus events
- COLORTERM=truecolor, unicode-width for CJK

### tmux Compatibility: 91% (20/22 prefix keys)

## Test plan
- [x] cargo clippy -D warnings: clean
- [x] cargo test: 43/43
- [x] E2E: 54/54
- [x] Feature QA: 50/50
- [x] Performance benchmark verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)