### PR TITLE
feat: v0.5.0 — multi-client, full-session snapshots, settings overhaul

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,27 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -36,10 +57,102 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
 
 [[package]]
 name = "crossterm"
@@ -68,10 +181,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "equivalent"
@@ -91,9 +216,10 @@ dependencies = [
 
 [[package]]
 name = "ezpn"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "anyhow",
+ "criterion",
  "crossterm",
  "libc",
  "portable-pty",
@@ -116,10 +242,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "indexmap"
@@ -138,6 +281,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7970510895cee30b3e9128319f2cefd4bde883a39f38baa279567ba3a7eb97d"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -221,6 +384,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -298,6 +482,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -308,6 +521,15 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -504,6 +726,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "toml"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -602,6 +834,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -622,6 +864,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -733,6 +984,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ezpn"
-version = "0.4.2"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.82"
 autobins = false
@@ -32,3 +32,10 @@ unicode-width = "0.2"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
+
+[dev-dependencies]
+criterion = { version = "0.5", default-features = false, features = ["cargo_bench_support"] }
+
+[[bench]]
+name = "render_hotpaths"
+harness = false

--- a/benches/render_hotpaths.rs
+++ b/benches/render_hotpaths.rs
@@ -1,0 +1,181 @@
+#![allow(dead_code)]
+
+use std::collections::{HashMap, HashSet};
+use std::time::Duration;
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+
+#[path = "../src/layout.rs"]
+mod layout;
+#[path = "../src/pane.rs"]
+mod pane;
+#[path = "../src/render.rs"]
+mod render;
+
+use layout::{Layout, Rect};
+use pane::{Pane, PaneLaunch};
+use render::BorderStyle;
+
+const TERM_W: u16 = 160;
+const TERM_H: u16 = 48;
+const SCROLLBACK: usize = 10_000;
+
+fn make_inner(tw: u16, th: u16, show_status_bar: bool) -> Rect {
+    let sh = if show_status_bar { 1u16 } else { 0 };
+    Rect {
+        x: 1,
+        y: 1,
+        w: tw.saturating_sub(2),
+        h: th.saturating_sub(sh + 2),
+    }
+}
+
+fn wait_for_initial_output(pane: &mut Pane) {
+    for _ in 0..50 {
+        if pane.read_output() {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    let _ = pane.read_output();
+}
+
+struct PaneFixture {
+    panes: HashMap<usize, Pane>,
+}
+
+impl Drop for PaneFixture {
+    fn drop(&mut self) {
+        for pane in self.panes.values_mut() {
+            pane.kill();
+        }
+    }
+}
+
+fn build_panes(layout: &Layout, show_status_bar: bool) -> PaneFixture {
+    let inner = make_inner(TERM_W, TERM_H, show_status_bar);
+    let rects = layout.pane_rects(&inner);
+    let mut panes = HashMap::new();
+
+    for (&pid, rect) in &rects {
+        let command = format!("printf 'pane {}\\nline 1\\nline 2\\n'; exec sleep 60", pid);
+        let mut pane = Pane::with_scrollback(
+            "/bin/sh",
+            PaneLaunch::Command(command),
+            rect.w.max(1),
+            rect.h.max(1),
+            SCROLLBACK,
+        )
+        .expect("spawn pane fixture");
+        wait_for_initial_output(&mut pane);
+        panes.insert(pid, pane);
+    }
+
+    PaneFixture { panes }
+}
+
+fn bench_border_cache(c: &mut Criterion) {
+    let mut group = c.benchmark_group("border_cache");
+    for (name, layout) in [
+        ("2x2", Layout::from_grid(2, 2)),
+        ("3x3", Layout::from_grid(3, 3)),
+    ] {
+        group.bench_with_input(BenchmarkId::from_parameter(name), &layout, |b, layout| {
+            b.iter(|| {
+                let cache = render::build_border_cache_with_style(
+                    layout,
+                    false,
+                    TERM_W,
+                    TERM_H,
+                    BorderStyle::Rounded,
+                );
+                criterion::black_box(cache);
+            });
+        });
+    }
+    group.finish();
+}
+
+fn bench_render(c: &mut Criterion) {
+    let mut group = c.benchmark_group("render");
+    for (name, layout) in [
+        ("2x2", Layout::from_grid(2, 2)),
+        ("3x3", Layout::from_grid(3, 3)),
+    ] {
+        let fixture = build_panes(&layout, false);
+        let cache = render::build_border_cache_with_style(
+            &layout,
+            false,
+            TERM_W,
+            TERM_H,
+            BorderStyle::Rounded,
+        );
+        let active = *cache
+            .pane_order()
+            .first()
+            .expect("pane order should not be empty");
+
+        group.bench_function(BenchmarkId::new("full_redraw", name), |b| {
+            let dirty = HashSet::new();
+            let mut buf = Vec::with_capacity(64 * 1024);
+            b.iter(|| {
+                buf.clear();
+                render::render_panes(
+                    &mut buf,
+                    &fixture.panes,
+                    &layout,
+                    active,
+                    BorderStyle::Rounded,
+                    false,
+                    TERM_W,
+                    TERM_H,
+                    false,
+                    &cache,
+                    &dirty,
+                    true,
+                    None,
+                    false,
+                )
+                .expect("full redraw render");
+                criterion::black_box(&buf);
+            });
+        });
+
+        group.bench_function(BenchmarkId::new("partial_redraw", name), |b| {
+            let mut dirty = HashSet::new();
+            dirty.insert(active);
+            let mut buf = Vec::with_capacity(64 * 1024);
+            b.iter(|| {
+                buf.clear();
+                render::render_panes(
+                    &mut buf,
+                    &fixture.panes,
+                    &layout,
+                    active,
+                    BorderStyle::Rounded,
+                    false,
+                    TERM_W,
+                    TERM_H,
+                    false,
+                    &cache,
+                    &dirty,
+                    false,
+                    None,
+                    false,
+                )
+                .expect("partial redraw render");
+                criterion::black_box(&buf);
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default()
+        .sample_size(20)
+        .measurement_time(Duration::from_secs(2));
+    targets = bench_border_cache, bench_render
+}
+criterion_main!(benches);

--- a/src/client.rs
+++ b/src/client.rs
@@ -28,7 +28,17 @@ pub enum ExitReason {
 }
 
 /// Connect to a running server and act as a terminal proxy.
+/// Uses legacy C_RESIZE handshake (steal mode).
 pub fn run(socket_path: &std::path::Path, session_name: &str) -> anyhow::Result<()> {
+    run_with_mode(socket_path, session_name, protocol::AttachMode::Steal)
+}
+
+/// Connect to a running server with a specific attach mode.
+pub fn run_with_mode(
+    socket_path: &std::path::Path,
+    session_name: &str,
+    attach_mode: protocol::AttachMode,
+) -> anyhow::Result<()> {
     let stream = UnixStream::connect(socket_path)?;
     stream.set_nonblocking(false)?;
 
@@ -66,7 +76,7 @@ pub fn run(socket_path: &std::path::Path, session_name: &str) -> anyhow::Result<
     let _ = write!(stdout, "\x1b]0;ezpn: {}\x07", session_name);
     let _ = stdout.flush();
 
-    let reason = client_loop(&mut stdout, write_stream, &server_rx);
+    let reason = client_loop(&mut stdout, write_stream, &server_rx, attach_mode);
 
     // Cleanup terminal FIRST — before printing any messages
     {
@@ -105,11 +115,24 @@ fn client_loop(
     stdout: &mut io::Stdout,
     mut writer: UnixStream,
     server_rx: &mpsc::Receiver<(u8, Vec<u8>)>,
+    attach_mode: protocol::AttachMode,
 ) -> anyhow::Result<ExitReason> {
-    // Send initial terminal size
+    // Send initial handshake with terminal size and attach mode
     let (cols, rows) = terminal::size()?;
-    let resize_data = protocol::encode_resize(cols, rows);
-    protocol::write_msg(&mut writer, protocol::C_RESIZE, &resize_data)?;
+    if attach_mode == protocol::AttachMode::Steal {
+        // Legacy handshake for backward compatibility
+        let resize_data = protocol::encode_resize(cols, rows);
+        protocol::write_msg(&mut writer, protocol::C_RESIZE, &resize_data)?;
+    } else {
+        // New protocol with attach mode
+        let req = protocol::AttachRequest {
+            cols,
+            rows,
+            mode: attach_mode,
+        };
+        let json = serde_json::to_vec(&req)?;
+        protocol::write_msg(&mut writer, protocol::C_ATTACH, &json)?;
+    }
 
     loop {
         // 1. Process server messages — batch all output, flush once
@@ -140,7 +163,10 @@ fn client_loop(
         }
 
         // 2. Read terminal events and forward to server
-        while event::poll(Duration::from_millis(8))? {
+        // Use 1ms poll when we had output (expect more soon), 4ms otherwise.
+        // This reduces input latency vs the previous 8ms fixed poll.
+        let poll_ms = if got_output { 1 } else { 4 };
+        while event::poll(Duration::from_millis(poll_ms))? {
             let ev = event::read()?;
 
             match &ev {

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,7 +53,7 @@ fn main() -> anyhow::Result<()> {
         Some("from") => return cmd_from(args.get(2).map(|s| s.as_str())),
         Some("ls") => return cmd_ls(),
         Some("kill") => return cmd_kill(args.get(2).map(|s| s.as_str())),
-        Some("a") | Some("attach") => return cmd_attach(args.get(2).map(|s| s.as_str())),
+        Some("a") | Some("attach") => return cmd_attach(&args[2..]),
         Some("rename") => {
             return cmd_rename(
                 args.get(2).map(|s| s.as_str()),
@@ -222,7 +222,20 @@ fn cmd_rename(old: Option<&str>, new: Option<&str>) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn cmd_attach(name: Option<&str>) -> anyhow::Result<()> {
+fn cmd_attach(args: &[String]) -> anyhow::Result<()> {
+    let mut name: Option<&str> = None;
+    let mut attach_mode = protocol::AttachMode::Steal;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--shared" => attach_mode = protocol::AttachMode::Shared,
+            "--readonly" => attach_mode = protocol::AttachMode::Readonly,
+            other if !other.starts_with('-') && name.is_none() => name = Some(other),
+            other => anyhow::bail!("unknown attach option: {}", other),
+        }
+        i += 1;
+    }
+
     let (session_name, path) = session::find(name).ok_or_else(|| {
         anyhow::anyhow!(
             "no session found{}",
@@ -235,7 +248,7 @@ fn cmd_attach(name: Option<&str>) -> anyhow::Result<()> {
         std::process::exit(1);
     }
 
-    client::run(&path, &session_name)
+    client::run_with_mode(&path, &session_name, attach_mode)
 }
 
 fn cmd_init() -> anyhow::Result<()> {
@@ -772,20 +785,22 @@ fn run(stdout: &mut io::Stdout, config: &Config) -> anyhow::Result<()> {
 
     let (mut layout, mut panes, mut active) = if let Some(path) = &config.restore {
         let snapshot = workspace::load_snapshot(path)?;
-        let layout = snapshot.layout.clone();
+        let tab = &snapshot.tabs[snapshot.active_tab];
+        let layout = tab.layout.clone();
         default_shell = snapshot.shell.clone();
         settings.border_style = snapshot.border_style;
         settings.show_status_bar = snapshot.show_status_bar;
+        settings.show_tab_bar = snapshot.show_tab_bar;
         let panes = spawn_snapshot_panes(
             &layout,
-            &snapshot,
+            tab,
             &default_shell,
             tw,
             th,
             &settings,
-            effective_scrollback,
+            snapshot.scrollback,
         )?;
-        let active = snapshot.active_pane;
+        let active = tab.active_pane;
         (layout, panes, active)
     } else if config.commands.is_empty()
         && matches!(config.layout, LayoutSpec::Grid { rows: 1, cols: 2 })
@@ -874,6 +889,7 @@ fn run(stdout: &mut io::Stdout, config: &Config) -> anyhow::Result<()> {
         .map_err(|e| eprintln!("ezpn: IPC unavailable ({e}), ezpn-ctl disabled"))
         .ok();
     let mut border_cache = render::build_border_cache(&layout, settings.show_status_bar, tw, th);
+    let mut last_title_state: Option<(usize, usize)> = None;
     let initial_dirty = layout.pane_ids().into_iter().collect::<HashSet<_>>();
     render_frame(
         stdout,
@@ -942,16 +958,23 @@ fn run(stdout: &mut io::Stdout, config: &Config) -> anyhow::Result<()> {
                     continue; // wait before restarting
                 }
 
-                let (launch, old_name) = panes
+                let (launch, old_name, pane_shell) = panes
                     .get(&pid)
-                    .map(|p| (p.launch().clone(), p.name().map(String::from)))
-                    .unwrap_or((PaneLaunch::Shell, None));
+                    .map(|p| {
+                        (
+                            p.launch().clone(),
+                            p.name().map(String::from),
+                            p.initial_shell().map(String::from),
+                        )
+                    })
+                    .unwrap_or((PaneLaunch::Shell, None, None));
+                let eff_shell = pane_shell.as_deref().unwrap_or(&default_shell);
                 if replace_pane(
                     &mut panes,
                     &layout,
                     pid,
                     launch,
-                    &default_shell,
+                    eff_shell,
                     tw,
                     th,
                     &settings,
@@ -959,9 +982,12 @@ fn run(stdout: &mut io::Stdout, config: &Config) -> anyhow::Result<()> {
                 )
                 .is_ok()
                 {
-                    // Preserve the pane name from config
+                    // Preserve pane name and shell override
                     if let Some(pane) = panes.get_mut(&pid) {
                         pane.set_name(old_name);
+                        if let Some(ref s) = pane_shell {
+                            pane.set_initial_shell(Some(s.clone()));
+                        }
                     }
                     *retries += 1;
                     *last_death = Instant::now();
@@ -1366,49 +1392,21 @@ fn run(stdout: &mut io::Stdout, config: &Config) -> anyhow::Result<()> {
                         else if settings.visible {
                             let prev_border = settings.border_style;
                             let prev_status = settings.show_status_bar;
+                            let prev_tab_bar = settings.show_tab_bar;
                             let action = settings.handle_key(key);
-                            match action {
-                                SettingsAction::SplitH => {
-                                    do_split(
-                                        &mut layout,
-                                        &mut panes,
-                                        active,
-                                        Direction::Horizontal,
-                                        &default_shell,
-                                        tw,
-                                        th,
-                                        &settings,
-                                        effective_scrollback,
-                                    )?;
-                                    update.mark_all(&layout);
-                                    update.border_dirty = true;
-                                }
-                                SettingsAction::SplitV => {
-                                    do_split(
-                                        &mut layout,
-                                        &mut panes,
-                                        active,
-                                        Direction::Vertical,
-                                        &default_shell,
-                                        tw,
-                                        th,
-                                        &settings,
-                                        effective_scrollback,
-                                    )?;
-                                    update.mark_all(&layout);
-                                    update.border_dirty = true;
-                                }
-                                _ => {}
+                            if action == SettingsAction::BroadcastToggle {
+                                broadcast = !broadcast;
                             }
                             if settings.border_style != prev_border {
                                 update.full_redraw = true;
                             }
-                            if settings.show_status_bar != prev_status {
+                            if settings.show_status_bar != prev_status
+                                || settings.show_tab_bar != prev_tab_bar
+                            {
                                 resize_all(&mut panes, &layout, tw, th, &settings);
                                 update.border_dirty = true;
                                 update.mark_all(&layout);
                             }
-                            // Any settings interaction needs a redraw (focus movement, value change, close)
                             {
                                 update.full_redraw = true;
                             }
@@ -1480,21 +1478,37 @@ fn run(stdout: &mut io::Stdout, config: &Config) -> anyhow::Result<()> {
                         } else if key.code == KeyCode::Enter
                             && panes.get(&active).is_some_and(|p| !p.is_alive())
                         {
-                            let launch = panes
+                            let (launch, old_name, pane_shell) = panes
                                 .get(&active)
-                                .map(|p| p.launch().clone())
-                                .unwrap_or(PaneLaunch::Shell);
-                            replace_pane(
+                                .map(|p| {
+                                    (
+                                        p.launch().clone(),
+                                        p.name().map(String::from),
+                                        p.initial_shell().map(String::from),
+                                    )
+                                })
+                                .unwrap_or((PaneLaunch::Shell, None, None));
+                            let eff_shell = pane_shell.as_deref().unwrap_or(&default_shell);
+                            if replace_pane(
                                 &mut panes,
                                 &layout,
                                 active,
                                 launch,
-                                &default_shell,
+                                eff_shell,
                                 tw,
                                 th,
                                 &settings,
                                 effective_scrollback,
-                            )?;
+                            )
+                            .is_ok()
+                            {
+                                if let Some(pane) = panes.get_mut(&active) {
+                                    pane.set_name(old_name);
+                                    if let Some(ref s) = pane_shell {
+                                        pane.set_initial_shell(Some(s.clone()));
+                                    }
+                                }
+                            }
                             update.dirty_panes.insert(active);
                         } else if broadcast {
                             // Broadcast: send key to all live panes
@@ -1525,52 +1539,24 @@ fn run(stdout: &mut io::Stdout, config: &Config) -> anyhow::Result<()> {
                             if settings.visible {
                                 let prev_border = settings.border_style;
                                 let prev_status = settings.show_status_bar;
+                                let prev_tab_bar = settings.show_tab_bar;
                                 let action = settings.handle_click(mouse.column, mouse.row, tw, th);
-                                match action {
-                                    SettingsAction::SplitH => {
-                                        do_split(
-                                            &mut layout,
-                                            &mut panes,
-                                            active,
-                                            Direction::Horizontal,
-                                            &default_shell,
-                                            tw,
-                                            th,
-                                            &settings,
-                                            effective_scrollback,
-                                        )?;
-                                        update.mark_all(&layout);
-                                        update.border_dirty = true;
-                                    }
-                                    SettingsAction::SplitV => {
-                                        do_split(
-                                            &mut layout,
-                                            &mut panes,
-                                            active,
-                                            Direction::Vertical,
-                                            &default_shell,
-                                            tw,
-                                            th,
-                                            &settings,
-                                            effective_scrollback,
-                                        )?;
-                                        update.mark_all(&layout);
-                                        update.border_dirty = true;
-                                    }
-                                    SettingsAction::Changed
-                                    | SettingsAction::Close
-                                    | SettingsAction::None => {}
+                                if action == SettingsAction::BroadcastToggle {
+                                    broadcast = !broadcast;
                                 }
                                 if settings.border_style != prev_border {
                                     update.full_redraw = true;
                                 }
-                                if settings.show_status_bar != prev_status {
+                                if settings.show_status_bar != prev_status
+                                    || settings.show_tab_bar != prev_tab_bar
+                                {
                                     resize_all(&mut panes, &layout, tw, th, &settings);
                                     update.border_dirty = true;
                                     update.mark_all(&layout);
                                 }
                                 if action == SettingsAction::Changed
                                     || action == SettingsAction::Close
+                                    || action == SettingsAction::BroadcastToggle
                                 {
                                     update.full_redraw = true;
                                 }
@@ -1842,11 +1828,6 @@ fn run(stdout: &mut io::Stdout, config: &Config) -> anyhow::Result<()> {
         }
 
         if update.needs_render() {
-            // Sync scrollback offsets to vt100 parser before rendering
-            for pane in panes.values_mut() {
-                pane.sync_scrollback();
-            }
-
             let mode_label = match &mode {
                 InputMode::Prefix { .. } => "PREFIX",
                 InputMode::ScrollMode => "SCROLL",
@@ -1858,11 +1839,24 @@ fn run(stdout: &mut io::Stdout, config: &Config) -> anyhow::Result<()> {
                 InputMode::Normal => "",
             };
 
+            let needs_selection_chars =
+                zoomed_pane.is_none() && settings.show_status_bar && text_selection.is_some();
+            let render_targets = collect_render_targets(
+                &panes,
+                &update.dirty_panes,
+                update.full_redraw,
+                zoomed_pane,
+                needs_selection_chars
+                    .then(|| text_selection.as_ref().map(|s| s.pane_id))
+                    .flatten(),
+            );
+            sync_render_targets(&mut panes, &render_targets);
+
             if let Some(zpid) = zoomed_pane {
                 // Zoomed mode: render only the zoomed pane at full size
                 queue!(stdout, terminal::BeginSynchronizedUpdate)?;
-                let ids = layout.pane_ids();
-                let pane_idx = ids.iter().position(|&id| id == zpid).unwrap_or(0);
+                let pane_order = border_cache.pane_order();
+                let pane_idx = pane_order.iter().position(|&id| id == zpid).unwrap_or(0);
                 let label = panes
                     .get(&zpid)
                     .map(|p| p.launch_label(&default_shell))
@@ -1892,7 +1886,7 @@ fn run(stdout: &mut io::Stdout, config: &Config) -> anyhow::Result<()> {
                         tw,
                         th,
                         pane_idx,
-                        ids.len(),
+                        pane_order.len(),
                         zoom_label,
                         pane_name,
                         0,
@@ -1905,23 +1899,11 @@ fn run(stdout: &mut io::Stdout, config: &Config) -> anyhow::Result<()> {
                     let (sr, sc, er, ec) = s.normalized();
                     (s.pane_id, sr, sc, er, ec)
                 });
-                // Compute selection char count for status bar
-                let sel_chars = text_selection
-                    .as_ref()
-                    .and_then(|sel| {
-                        panes.get(&sel.pane_id).map(|pane| {
-                            let text = extract_selected_text(
-                                pane.screen(),
-                                sel.pane_id,
-                                sel.start_row,
-                                sel.start_col,
-                                sel.end_row,
-                                sel.end_col,
-                            );
-                            text.chars().count()
-                        })
-                    })
-                    .unwrap_or(0);
+                let sel_chars = if needs_selection_chars {
+                    selection_char_count_from_synced(&panes, sel_for_render)
+                } else {
+                    0
+                };
                 render_frame(
                     stdout,
                     &panes,
@@ -1956,17 +1938,18 @@ fn run(stdout: &mut io::Stdout, config: &Config) -> anyhow::Result<()> {
                 stdout.flush()?;
             }
 
-            // Reset scrollback view so process() isn't affected
-            for pane in panes.values_mut() {
-                pane.reset_scrollback_view();
-            }
+            reset_render_targets(&mut panes, &render_targets);
         }
 
         // Update window title with pane count
         {
-            let ids = layout.pane_ids();
-            let idx = ids.iter().position(|&id| id == active).unwrap_or(0);
-            let _ = write!(stdout, "\x1b]0;ezpn [{}/{}]\x07", idx + 1, ids.len());
+            let pane_order = border_cache.pane_order();
+            let idx = pane_order.iter().position(|&id| id == active).unwrap_or(0);
+            let next_title = (idx, pane_order.len());
+            if last_title_state != Some(next_title) {
+                let _ = write!(stdout, "\x1b]0;ezpn [{}/{}]\x07", idx + 1, pane_order.len());
+                last_title_state = Some(next_title);
+            }
         }
     }
 
@@ -2041,22 +2024,22 @@ fn render_frame(
     )?;
     // Mode-aware status bar (render over the default one if we have a mode)
     if settings.show_status_bar && (!mode_label.is_empty() || selection_chars > 0) {
-        let ids = layout.pane_ids();
-        let active_idx = ids.iter().position(|&id| id == active).unwrap_or(0);
+        let pane_order = border_cache.pane_order();
+        let active_idx = pane_order.iter().position(|&id| id == active).unwrap_or(0);
         let pane_name = panes.get(&active).and_then(|p| p.name()).unwrap_or("");
         render::draw_status_bar_full(
             stdout,
             tw,
             th,
             active_idx,
-            ids.len(),
+            pane_order.len(),
             mode_label,
             pane_name,
             selection_chars,
         )?;
     }
     if settings.visible {
-        settings.render_overlay(stdout, tw, th)?;
+        settings.render_overlay(stdout, tw, th, broadcast)?;
         queue!(stdout, cursor::Hide)?; // no blinking cursor over modal
     }
     queue!(stdout, terminal::EndSynchronizedUpdate)?;
@@ -2064,8 +2047,81 @@ fn render_frame(
     Ok(())
 }
 
+fn collect_render_targets(
+    panes: &HashMap<usize, Pane>,
+    dirty_panes: &HashSet<usize>,
+    full_redraw: bool,
+    zoomed_pane: Option<usize>,
+    extra_pane: Option<usize>,
+) -> Vec<usize> {
+    let mut targets = if let Some(pid) = zoomed_pane {
+        let mut out = Vec::with_capacity(1 + usize::from(extra_pane.is_some()));
+        if panes.contains_key(&pid) {
+            out.push(pid);
+        }
+        out
+    } else if full_redraw {
+        panes.keys().copied().collect::<Vec<_>>()
+    } else {
+        dirty_panes
+            .iter()
+            .copied()
+            .filter(|pid| panes.contains_key(pid))
+            .collect::<Vec<_>>()
+    };
+
+    if let Some(pid) = extra_pane {
+        if panes.contains_key(&pid) && !targets.contains(&pid) {
+            targets.push(pid);
+        }
+    }
+
+    targets
+}
+
+fn sync_render_targets(panes: &mut HashMap<usize, Pane>, targets: &[usize]) {
+    for pid in targets {
+        if let Some(pane) = panes.get_mut(pid) {
+            pane.sync_scrollback();
+        }
+    }
+}
+
+fn reset_render_targets(panes: &mut HashMap<usize, Pane>, targets: &[usize]) {
+    for pid in targets {
+        if let Some(pane) = panes.get_mut(pid) {
+            pane.reset_scrollback_view();
+        }
+    }
+}
+
+fn selection_char_count_from_synced(
+    panes: &HashMap<usize, Pane>,
+    selection: render::PaneSelection,
+) -> usize {
+    selection
+        .and_then(|(pane_id, sr, sc, er, ec)| {
+            panes.get(&pane_id).map(|pane| {
+                let text = extract_selected_text(pane.screen(), pane_id, sr, sc, er, ec);
+                text.chars().count()
+            })
+        })
+        .unwrap_or(0)
+}
+
+/// Extra state from a snapshot restore (all tabs in order).
+pub(crate) struct SnapshotExtra {
+    /// All tabs in their original order.
+    pub all_tabs: Vec<workspace::TabSnapshot>,
+    /// Which index in `all_tabs` is the active one (already spawned by build_initial_state).
+    pub active_tab_idx: usize,
+    /// The snapshot's scrollback value (for consistency across all tabs).
+    pub scrollback: usize,
+}
+
 /// Build initial layout, panes, and active pane ID from config.
 /// Used by both direct mode and server mode.
+/// Returns optional `SnapshotExtra` when restoring a multi-tab snapshot.
 #[allow(clippy::type_complexity)]
 pub(crate) fn build_initial_state(
     config: &Config,
@@ -2073,7 +2129,7 @@ pub(crate) fn build_initial_state(
     settings: &mut Settings,
     restart_policies: &mut HashMap<usize, project::RestartPolicy>,
     scrollback: usize,
-) -> anyhow::Result<(Layout, HashMap<usize, Pane>, usize)> {
+) -> anyhow::Result<(Layout, HashMap<usize, Pane>, usize, Option<SnapshotExtra>)> {
     // Use a default terminal size for initial spawn (server doesn't have a terminal yet).
     // Panes will be resized when a client connects.
     let tw: u16 = 80;
@@ -2081,21 +2137,41 @@ pub(crate) fn build_initial_state(
 
     if let Some(path) = &config.restore {
         let snapshot = workspace::load_snapshot(path)?;
-        let layout = snapshot.layout.clone();
+        let active_idx = snapshot.active_tab;
+        let tab = &snapshot.tabs[active_idx];
+        let layout = tab.layout.clone();
         *default_shell = snapshot.shell.clone();
         settings.border_style = snapshot.border_style;
         settings.show_status_bar = snapshot.show_status_bar;
+        settings.show_tab_bar = snapshot.show_tab_bar;
+        let effective_scrollback = snapshot.scrollback;
+
+        // Restore restart policies from snapshot
+        for ps in &tab.panes {
+            if ps.restart != project::RestartPolicy::Never {
+                restart_policies.insert(ps.id, ps.restart.clone());
+            }
+        }
+
         let panes = spawn_snapshot_panes(
             &layout,
-            &snapshot,
+            tab,
             default_shell,
             tw,
             th,
             settings,
-            scrollback,
+            effective_scrollback,
         )?;
-        let active = snapshot.active_pane;
-        return Ok((layout, panes, active));
+        let active = tab.active_pane;
+
+        // Pass all tabs to the caller for full restore
+        let extra = Some(SnapshotExtra {
+            all_tabs: snapshot.tabs.clone(),
+            active_tab_idx: active_idx,
+            scrollback: effective_scrollback,
+        });
+
+        return Ok((layout, panes, active, extra));
     }
 
     if config.commands.is_empty() && matches!(config.layout, LayoutSpec::Grid { rows: 1, cols: 2 })
@@ -2105,7 +2181,7 @@ pub(crate) fn build_initial_state(
             let panes = spawn_project_panes(&proj, default_shell, tw, th, settings, scrollback)?;
             *restart_policies = proj.restarts.clone();
             let active = *proj.layout.pane_ids().first().unwrap_or(&0);
-            return Ok((proj.layout, panes, active));
+            return Ok((proj.layout, panes, active, None));
         } else if let Some((layout, launches)) = try_load_procfile() {
             let panes = spawn_layout_panes(
                 &layout,
@@ -2117,7 +2193,7 @@ pub(crate) fn build_initial_state(
                 scrollback,
             )?;
             let active = *layout.pane_ids().first().unwrap_or(&0);
-            return Ok((layout, panes, active));
+            return Ok((layout, panes, active, None));
         } else {
             let layout = Layout::from_grid(1, 2);
             let panes = spawn_layout_panes(
@@ -2130,7 +2206,7 @@ pub(crate) fn build_initial_state(
                 scrollback,
             )?;
             let active = *layout.pane_ids().first().unwrap_or(&0);
-            return Ok((layout, panes, active));
+            return Ok((layout, panes, active, None));
         }
     }
 
@@ -2150,7 +2226,7 @@ pub(crate) fn build_initial_state(
         scrollback,
     )?;
     let active = *layout.pane_ids().first().unwrap_or(&0);
-    Ok((layout, panes, active))
+    Ok((layout, panes, active, None))
 }
 
 /// Extract selected text — server-friendly version that takes individual coords.
@@ -2252,14 +2328,6 @@ pub(crate) fn build_command_launches(
         .collect()
 }
 
-fn build_snapshot_launches(snapshot: &WorkspaceSnapshot) -> HashMap<usize, PaneLaunch> {
-    snapshot
-        .panes
-        .iter()
-        .map(|pane| (pane.id, pane.launch.clone()))
-        .collect()
-}
-
 pub(crate) fn spawn_layout_panes(
     layout: &Layout,
     launches: HashMap<usize, PaneLaunch>,
@@ -2305,24 +2373,49 @@ pub(crate) fn spawn_layout_panes(
     Ok(panes)
 }
 
-fn spawn_snapshot_panes(
+pub(crate) fn spawn_snapshot_panes(
     layout: &Layout,
-    snapshot: &WorkspaceSnapshot,
+    tab: &workspace::TabSnapshot,
     shell: &str,
     tw: u16,
     th: u16,
     settings: &Settings,
     scrollback: usize,
 ) -> anyhow::Result<HashMap<usize, Pane>> {
-    spawn_layout_panes(
-        layout,
-        build_snapshot_launches(snapshot),
-        shell,
-        tw,
-        th,
-        settings,
-        scrollback,
-    )
+    let inner = make_inner(tw, th, settings.show_status_bar);
+    let rects = layout.pane_rects(&inner);
+    let mut panes = HashMap::new();
+
+    for ps in &tab.panes {
+        let rect = rects.get(&ps.id).cloned().unwrap_or(crate::layout::Rect {
+            x: 0,
+            y: 0,
+            w: 80,
+            h: 24,
+        });
+        let cols = rect.w.max(1);
+        let rows = rect.h.max(1);
+        let pane_shell = ps.shell.as_deref().unwrap_or(shell);
+        let cwd = ps.cwd.as_ref().map(std::path::PathBuf::from);
+        let cwd_ref = cwd.as_deref();
+        let mut pane = Pane::with_full_config(
+            pane_shell,
+            ps.launch.clone(),
+            cols,
+            rows,
+            scrollback,
+            cwd_ref,
+            &ps.env,
+        )?;
+        if let Some(name) = &ps.name {
+            pane.set_name(Some(name.clone()));
+        }
+        if ps.shell.is_some() {
+            pane.set_initial_shell(ps.shell.clone());
+        }
+        panes.insert(ps.id, pane);
+    }
+    Ok(panes)
 }
 
 pub(crate) fn spawn_pane(
@@ -2363,6 +2456,10 @@ pub(crate) fn spawn_project_panes(
         if let Some(name) = proj.names.get(&pid) {
             pane.set_name(Some(name.clone()));
         }
+        // Track per-pane shell override for snapshot/restart
+        if proj.shells.contains_key(&pid) {
+            pane.set_initial_shell(Some(pane_shell.to_string()));
+        }
         panes.insert(pid, pane);
     }
     Ok(panes)
@@ -2380,12 +2477,31 @@ pub(crate) fn replace_pane(
     settings: &Settings,
     scrollback: usize,
 ) -> anyhow::Result<()> {
+    // Extract cwd/env from the old pane before replacing
+    let (cwd, env) = panes
+        .get(&pane_id)
+        .map(|p| {
+            (
+                p.live_cwd()
+                    .or_else(|| p.initial_cwd().map(|c| c.to_path_buf())),
+                p.initial_env().clone(),
+            )
+        })
+        .unwrap_or((None, std::collections::HashMap::new()));
     let inner = make_inner(tw, th, settings.show_status_bar);
     let rect = layout
         .pane_rects(&inner)
         .remove(&pane_id)
         .ok_or_else(|| anyhow::anyhow!("pane rect not found"))?;
-    let new_pane = spawn_pane(shell, &launch, rect.w.max(1), rect.h.max(1), scrollback)?;
+    let new_pane = Pane::with_full_config(
+        shell,
+        launch,
+        rect.w.max(1),
+        rect.h.max(1),
+        scrollback,
+        cwd.as_deref(),
+        &env,
+    )?;
     if let Some(mut old_pane) = panes.insert(pane_id, new_pane) {
         old_pane.kill();
     }
@@ -2408,19 +2524,21 @@ fn apply_snapshot(
     settings: &mut Settings,
     tw: u16,
     th: u16,
-    scrollback: usize,
+    _scrollback: usize,
 ) -> anyhow::Result<()> {
+    let tab = &snapshot.tabs[snapshot.active_tab];
     let mut next_settings = Settings::new(snapshot.border_style);
     next_settings.show_status_bar = snapshot.show_status_bar;
-    let next_layout = snapshot.layout.clone();
+    next_settings.show_tab_bar = snapshot.show_tab_bar;
+    let next_layout = tab.layout.clone();
     let next_panes = spawn_snapshot_panes(
         &next_layout,
-        &snapshot,
+        tab,
         &snapshot.shell,
         tw,
         th,
         &next_settings,
-        scrollback,
+        snapshot.scrollback,
     )?;
 
     kill_all_panes(panes);
@@ -2429,7 +2547,7 @@ fn apply_snapshot(
     *panes = next_panes;
     *settings = next_settings;
     settings.visible = false;
-    *active = snapshot.active_pane;
+    *active = tab.active_pane;
     Ok(())
 }
 
@@ -2756,14 +2874,44 @@ pub(crate) fn handle_ipc_command(
             }
         }
         ipc::IpcRequest::Save { path } => {
-            let snapshot = WorkspaceSnapshot::from_live(
-                layout,
-                panes,
-                *active,
-                shell,
-                settings.border_style,
-                settings.show_status_bar,
-            );
+            // IPC save uses a single-tab snapshot (no TabManager available here)
+            let tab = workspace::TabSnapshot {
+                name: "1".to_string(),
+                layout: layout.clone(),
+                active_pane: *active,
+                zoomed_pane: None,
+                broadcast: false,
+                panes: layout
+                    .pane_ids()
+                    .into_iter()
+                    .map(|id| {
+                        let pane = panes.get(&id);
+                        workspace::PaneSnapshot {
+                            id,
+                            launch: pane
+                                .map(|p| p.launch().clone())
+                                .unwrap_or(PaneLaunch::Shell),
+                            name: pane.and_then(|p| p.name().map(|s| s.to_string())),
+                            cwd: pane
+                                .and_then(|p| p.live_cwd())
+                                .map(|p| p.to_string_lossy().to_string()),
+                            env: pane.map(|p| p.initial_env().clone()).unwrap_or_default(),
+                            restart: project::RestartPolicy::default(),
+                            shell: pane.and_then(|p| p.initial_shell().map(|s| s.to_string())),
+                        }
+                    })
+                    .collect(),
+            };
+            let snapshot = WorkspaceSnapshot {
+                version: 2,
+                shell: shell.clone(),
+                border_style: settings.border_style,
+                show_status_bar: settings.show_status_bar,
+                show_tab_bar: settings.show_tab_bar,
+                scrollback,
+                active_tab: 0,
+                tabs: vec![tab],
+            };
             match workspace::save_snapshot(&path, &snapshot) {
                 Ok(()) => ipc::IpcResponse::success(format!("saved {}", path)),
                 Err(error) => ipc::IpcResponse::error(error.to_string()),

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::io::{Read, Write};
 use std::sync::mpsc::{self, Receiver, TryRecvError};
 use std::sync::OnceLock;
@@ -22,6 +23,8 @@ pub fn wake_main_loop() {
         let _ = tx.send(());
     }
 }
+use std::path::PathBuf;
+
 use portable_pty::{native_pty_system, Child, CommandBuilder, MasterPty, PtySize};
 use serde::{Deserialize, Serialize};
 
@@ -49,6 +52,12 @@ pub struct Pane {
     bracketed_paste: bool,
     /// Whether the child has requested focus events (\x1b[?1004h).
     focus_events: bool,
+    /// The working directory this pane was launched with.
+    initial_cwd: Option<PathBuf>,
+    /// Custom env vars this pane was launched with.
+    initial_env: HashMap<String, String>,
+    /// Custom shell override for this pane (if different from default).
+    initial_shell: Option<String>,
 }
 
 impl Pane {
@@ -176,6 +185,9 @@ impl Pane {
             osc52_pending: Vec::new(),
             bracketed_paste: false,
             focus_events: false,
+            initial_cwd: cwd.map(|p| p.to_path_buf()),
+            initial_env: env.clone(),
+            initial_shell: None,
         })
     }
 
@@ -394,6 +406,73 @@ impl Pane {
     /// Whether the child has requested focus events.
     pub fn wants_focus(&self) -> bool {
         self.focus_events
+    }
+
+    /// The working directory this pane was launched with.
+    pub fn initial_cwd(&self) -> Option<&std::path::Path> {
+        self.initial_cwd.as_deref()
+    }
+
+    /// Custom env vars this pane was launched with.
+    pub fn initial_env(&self) -> &HashMap<String, String> {
+        &self.initial_env
+    }
+
+    /// Custom shell override for this pane.
+    pub fn initial_shell(&self) -> Option<&str> {
+        self.initial_shell.as_deref()
+    }
+
+    /// Set the custom shell for this pane (for snapshot purposes).
+    pub fn set_initial_shell(&mut self, shell: Option<String>) {
+        self.initial_shell = shell;
+    }
+
+    /// Try to get the current working directory of the child process.
+    /// Falls back to the initial cwd if the child has exited.
+    #[cfg(target_os = "macos")]
+    pub fn live_cwd(&self) -> Option<PathBuf> {
+        if self.alive {
+            if let Some(pid) = self.child.process_id() {
+                // Use proc_pidinfo on macOS
+                let mut vinfo: libc::proc_vnodepathinfo = unsafe { std::mem::zeroed() };
+                let ret = unsafe {
+                    libc::proc_pidinfo(
+                        pid as libc::c_int,
+                        libc::PROC_PIDVNODEPATHINFO,
+                        0,
+                        &mut vinfo as *mut _ as *mut libc::c_void,
+                        std::mem::size_of::<libc::proc_vnodepathinfo>() as libc::c_int,
+                    )
+                };
+                if ret > 0 {
+                    let cstr = unsafe {
+                        std::ffi::CStr::from_ptr(vinfo.pvi_cdir.vip_path.as_ptr() as *const i8)
+                    };
+                    if let Ok(s) = cstr.to_str() {
+                        if !s.is_empty() {
+                            return Some(PathBuf::from(s));
+                        }
+                    }
+                }
+            }
+        }
+        self.initial_cwd.clone()
+    }
+
+    /// Try to get the current working directory of the child process.
+    /// Falls back to the initial cwd if the child has exited.
+    #[cfg(not(target_os = "macos"))]
+    pub fn live_cwd(&self) -> Option<PathBuf> {
+        if self.alive {
+            if let Some(pid) = self.child.process_id() {
+                let link = format!("/proc/{}/cwd", pid);
+                if let Ok(cwd) = std::fs::read_link(&link) {
+                    return Some(cwd);
+                }
+            }
+        }
+        self.initial_cwd.clone()
     }
 }
 

--- a/src/project.rs
+++ b/src/project.rs
@@ -19,7 +19,7 @@
 //! cwd = "./frontend"
 //! ```
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
@@ -41,7 +41,7 @@ pub struct WorkspaceSection {
     pub cols: Option<usize>,
 }
 
-#[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum RestartPolicy {
     #[default]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -16,6 +16,8 @@ pub const C_RESIZE: u8 = 0x03;
 pub const C_KILL: u8 = 0x04;
 /// Lightweight liveness probe (sent by `ezpn ls`). No side effects.
 pub const C_PING: u8 = 0x05;
+/// Client attach with mode. Payload = JSON `AttachRequest`.
+pub const C_ATTACH: u8 = 0x06;
 
 // ── Server → Client tags ──
 
@@ -83,4 +85,66 @@ pub fn decode_resize(payload: &[u8]) -> Option<(u16, u16)> {
     let cols = u16::from_be_bytes([payload[0], payload[1]]);
     let rows = u16::from_be_bytes([payload[2], payload[3]]);
     Some((cols, rows))
+}
+
+/// How a client wants to attach to a session.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AttachMode {
+    /// Default: detach any existing client (legacy behavior).
+    #[default]
+    Steal,
+    /// Shared session: all clients can send input and see output.
+    Shared,
+    /// Read-only: client can only observe, no input forwarded.
+    Readonly,
+}
+
+/// Attach request sent by C_ATTACH.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct AttachRequest {
+    pub cols: u16,
+    pub rows: u16,
+    pub mode: AttachMode,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn attach_request_round_trip() {
+        let req = AttachRequest {
+            cols: 120,
+            rows: 40,
+            mode: AttachMode::Shared,
+        };
+        let json = serde_json::to_vec(&req).unwrap();
+        let decoded: AttachRequest = serde_json::from_slice(&json).unwrap();
+        assert_eq!(decoded.cols, 120);
+        assert_eq!(decoded.rows, 40);
+        assert_eq!(decoded.mode, AttachMode::Shared);
+    }
+
+    #[test]
+    fn attach_mode_default_is_steal() {
+        assert_eq!(AttachMode::default(), AttachMode::Steal);
+    }
+
+    #[test]
+    fn resize_encode_decode() {
+        let encoded = encode_resize(200, 50);
+        let (cols, rows) = decode_resize(&encoded).unwrap();
+        assert_eq!(cols, 200);
+        assert_eq!(rows, 50);
+    }
+
+    #[test]
+    fn framed_message_round_trip() {
+        let mut buf: Vec<u8> = Vec::new();
+        write_msg(&mut buf, C_EVENT, b"hello").unwrap();
+        let (tag, payload) = read_msg(&mut buf.as_slice()).unwrap();
+        assert_eq!(tag, C_EVENT);
+        assert_eq!(payload, b"hello");
+    }
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -163,11 +163,16 @@ pub struct BorderCell {
 
 pub struct BorderCache {
     inner: Rect,
+    pane_order: Vec<usize>,
     pane_rects: HashMap<usize, Rect>,
     cells: Vec<BorderCell>,
 }
 
 impl BorderCache {
+    pub fn pane_order(&self) -> &[usize] {
+        &self.pane_order
+    }
+
     pub fn pane_rects(&self) -> &HashMap<usize, Rect> {
         &self.pane_rects
     }
@@ -283,6 +288,7 @@ pub fn build_border_cache_with_style(
         }
     };
 
+    let pane_order = layout.pane_ids();
     let pane_rects = layout.pane_rects(&inner);
     let separators = layout.separators(&inner, &outer);
 
@@ -311,6 +317,7 @@ pub fn build_border_cache_with_style(
 
     BorderCache {
         inner,
+        pane_order,
         pane_rects,
         cells,
     }
@@ -326,7 +333,7 @@ pub type PaneSelection = Option<(usize, u16, u16, u16, u16)>;
 pub fn render_panes(
     stdout: &mut impl Write,
     panes: &HashMap<usize, Pane>,
-    layout: &Layout,
+    _layout: &Layout,
     active_id: usize,
     border_style: BorderStyle,
     show_status_bar: bool,
@@ -397,7 +404,7 @@ pub fn render_panes(
     }
 
     // Pane titles + content
-    let ids = layout.pane_ids();
+    let ids = border_cache.pane_order();
     for (display_idx, &pid) in ids.iter().enumerate() {
         if !full_redraw && !dirty_panes.contains(&pid) {
             continue;
@@ -469,11 +476,14 @@ fn clear_rect(stdout: &mut impl Write, rect: &Rect) -> anyhow::Result<()> {
         return Ok(());
     }
 
+    let blanks = " ".repeat(rect.w as usize);
     for row in 0..rect.h {
-        queue!(stdout, cursor::MoveTo(rect.x, rect.y + row))?;
-        for _ in 0..rect.w {
-            queue!(stdout, ResetColor, Print(" "))?;
-        }
+        queue!(
+            stdout,
+            cursor::MoveTo(rect.x, rect.y + row),
+            ResetColor,
+            Print(&blanks)
+        )?;
     }
 
     Ok(())
@@ -486,11 +496,8 @@ fn clear_title(stdout: &mut impl Write, rect: &Rect) -> anyhow::Result<()> {
 
     let y = rect.y.saturating_sub(1);
     let x = rect.x;
-    let width = rect.w;
-    queue!(stdout, cursor::MoveTo(x, y))?;
-    for _ in 0..width {
-        queue!(stdout, ResetColor, Print(" "))?;
-    }
+    let blanks = " ".repeat(rect.w as usize);
+    queue!(stdout, cursor::MoveTo(x, y), ResetColor, Print(&blanks))?;
     Ok(())
 }
 
@@ -593,9 +600,8 @@ fn draw_pane_title(
                 cursor::MoveTo(title_x, title_y),
                 SetBackgroundColor(title_bg),
             )?;
-            for _ in 0..avail {
-                queue!(stdout, Print(" "))?;
-            }
+            let blanks = " ".repeat(avail);
+            queue!(stdout, Print(&blanks))?;
             queue!(stdout, cursor::MoveTo(title_x, title_y))?;
         } else {
             queue!(

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,7 +1,8 @@
 //! Server daemon that manages PTYs, layout, and state.
 //!
-//! Accepts one client at a time. Renders frames to a buffer and streams
-//! them to the connected client. Goes headless when no client is attached.
+//! Accepts multiple clients with attach modes (steal/shared/readonly).
+//! Renders frames to a buffer and streams them to all connected clients.
+//! Goes headless when no client is attached.
 
 use std::collections::{HashMap, HashSet};
 use std::io::BufReader;
@@ -23,6 +24,7 @@ use crate::protocol;
 use crate::render::{self, BorderCache};
 use crate::session;
 use crate::settings::{Settings, SettingsAction};
+use crate::workspace::{self, WorkspaceSnapshot};
 
 /// Input state machine for prefix key support.
 #[allow(dead_code)]
@@ -129,19 +131,40 @@ enum ClientMsg {
     Kill,
 }
 
-/// Connected client state.
-struct ClientConn {
+/// Connected client with attach mode and per-client state.
+struct ConnectedClient {
+    id: u64,
     writer: std::io::BufWriter<UnixStream>,
     event_rx: mpsc::Receiver<ClientMsg>,
+    mode: protocol::AttachMode,
+    tw: u16,
+    th: u16,
 }
 
-impl Drop for ClientConn {
+impl Drop for ConnectedClient {
     fn drop(&mut self) {
         // Shutdown the underlying socket to force the reader thread to exit.
-        // BufWriter wraps the UnixStream; get_ref() gives us the inner stream.
         let _ = self.writer.get_ref().shutdown(std::net::Shutdown::Both);
     }
 }
+
+/// Compute the effective terminal size from all active clients.
+/// Uses smallest-client policy (like tmux).
+fn effective_size(clients: &[ConnectedClient]) -> (u16, u16) {
+    let mut min_w: u16 = u16::MAX;
+    let mut min_h: u16 = u16::MAX;
+    for c in clients {
+        min_w = min_w.min(c.tw);
+        min_h = min_h.min(c.th);
+    }
+    if min_w == u16::MAX {
+        (80, 24)
+    } else {
+        (min_w, min_h)
+    }
+}
+
+static NEXT_CLIENT_ID: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
 
 /// Run the server daemon. This function does not return until all panes die
 /// or the server is killed.
@@ -163,13 +186,14 @@ pub fn run(session_name: &str, args: &[String]) -> anyhow::Result<()> {
     };
     let mut settings = Settings::new(effective_border);
     settings.show_status_bar = file_config.show_status_bar;
+    settings.show_tab_bar = file_config.show_tab_bar;
     let prefix_key = file_config.prefix_key;
 
     // Auto-restart state
     let mut restart_policies: HashMap<usize, project::RestartPolicy> = HashMap::new();
 
     // Build layout and spawn panes (same logic as direct mode)
-    let (mut layout, mut panes, mut active) = super::build_initial_state(
+    let (mut layout, mut panes, mut active, snapshot_extra) = super::build_initial_state(
         &config,
         &mut default_shell,
         &mut settings,
@@ -191,6 +215,66 @@ pub fn run(session_name: &str, args: &[String]) -> anyhow::Result<()> {
     use crate::tab::{Tab, TabManager};
     let mut tab_mgr = TabManager::new();
     let mut tab_name = String::from("1");
+    let mut tab_names_cache: Vec<(usize, String, bool)> = Vec::new();
+    let mut tab_names_dirty = true;
+
+    // Restore all tabs from snapshot, preserving original order.
+    if let Some(extra) = snapshot_extra {
+        if extra.all_tabs.len() > 1 {
+            // Spawn ALL tabs in original order, using snapshot's scrollback
+            let mut all_spawned: Vec<Tab> = Vec::with_capacity(extra.all_tabs.len());
+            let snap_scrollback = extra.scrollback;
+
+            for tab_snap in &extra.all_tabs {
+                let tab_panes = super::spawn_snapshot_panes(
+                    &tab_snap.layout,
+                    tab_snap,
+                    &default_shell,
+                    80,
+                    24,
+                    &settings,
+                    snap_scrollback,
+                )?;
+                let mut tab_restart = HashMap::new();
+                for ps in &tab_snap.panes {
+                    if ps.restart != project::RestartPolicy::Never {
+                        tab_restart.insert(ps.id, ps.restart.clone());
+                    }
+                }
+                let mut tab = Tab::new(
+                    tab_snap.name.clone(),
+                    tab_snap.layout.clone(),
+                    tab_panes,
+                    tab_snap.active_pane,
+                );
+                tab.restart_policies = tab_restart;
+                tab.zoomed_pane = tab_snap.zoomed_pane;
+                tab.broadcast = tab_snap.broadcast;
+                all_spawned.push(tab);
+            }
+
+            // Kill the panes from build_initial_state (we re-spawned everything)
+            super::kill_all_panes(&mut panes);
+
+            // Build TabManager with correct order; active tab is unpacked
+            let (new_mgr, active_tab) = TabManager::from_tabs(all_spawned, extra.active_tab_idx);
+            tab_mgr = new_mgr;
+            tab_name = active_tab.name;
+            layout = active_tab.layout;
+            panes = active_tab.panes;
+            active = active_tab.active_pane;
+            restart_policies = active_tab.restart_policies;
+            restart_state = active_tab.restart_state;
+            zoomed_pane = active_tab.zoomed_pane;
+            broadcast = active_tab.broadcast;
+        } else {
+            // Single tab — just apply metadata
+            let snap = &extra.all_tabs[0];
+            tab_name = snap.name.clone();
+            zoomed_pane = snap.zoomed_pane;
+            broadcast = snap.broadcast;
+        }
+    }
     const MAX_RESTART_RETRIES: u32 = 10;
     const RESTART_DELAY: Duration = Duration::from_secs(2);
     const RESTART_BACKOFF_THRESHOLD: u32 = 3;
@@ -219,7 +303,7 @@ pub fn run(session_name: &str, args: &[String]) -> anyhow::Result<()> {
         let _ = std::fs::set_permissions(&sock_path, std::fs::Permissions::from_mode(0o600));
     }
 
-    let mut client: Option<ClientConn> = None;
+    let mut clients: Vec<ConnectedClient> = Vec::new();
     let mut border_cache: Option<BorderCache> = None;
     let mut render_buf: Vec<u8> = Vec::with_capacity(64 * 1024); // Reusable render buffer
 
@@ -251,12 +335,12 @@ pub fn run(session_name: &str, args: &[String]) -> anyhow::Result<()> {
             if pane.read_output() {
                 update.dirty_panes.insert(pid);
             }
-            // Forward OSC 52 clipboard sequences from child to client terminal
+            // Forward OSC 52 clipboard sequences from child to all clients
             let osc52_seqs = pane.take_osc52();
             if !osc52_seqs.is_empty() {
-                if let Some(ref mut c) = client {
-                    for seq in osc52_seqs {
-                        let _ = protocol::write_msg(&mut c.writer, protocol::S_OUTPUT, &seq);
+                for c in &mut clients {
+                    for seq in &osc52_seqs {
+                        let _ = protocol::write_msg(&mut c.writer, protocol::S_OUTPUT, seq);
                     }
                 }
             }
@@ -295,16 +379,23 @@ pub fn run(session_name: &str, args: &[String]) -> anyhow::Result<()> {
                     continue;
                 }
 
-                let (launch, old_name) = panes
+                let (launch, old_name, pane_shell) = panes
                     .get(&pid)
-                    .map(|p| (p.launch().clone(), p.name().map(String::from)))
-                    .unwrap_or((PaneLaunch::Shell, None));
+                    .map(|p| {
+                        (
+                            p.launch().clone(),
+                            p.name().map(String::from),
+                            p.initial_shell().map(String::from),
+                        )
+                    })
+                    .unwrap_or((PaneLaunch::Shell, None, None));
+                let effective_shell = pane_shell.as_deref().unwrap_or(&default_shell);
                 if super::replace_pane(
                     &mut panes,
                     &layout,
                     pid,
                     launch,
-                    &default_shell,
+                    effective_shell,
                     tw,
                     th,
                     &settings,
@@ -314,6 +405,9 @@ pub fn run(session_name: &str, args: &[String]) -> anyhow::Result<()> {
                 {
                     if let Some(pane) = panes.get_mut(&pid) {
                         pane.set_name(old_name);
+                        if let Some(ref shell_override) = pane_shell {
+                            pane.set_initial_shell(Some(shell_override.clone()));
+                        }
                     }
                     *retries += 1;
                     *last_death = Instant::now();
@@ -371,7 +465,7 @@ pub fn run(session_name: &str, args: &[String]) -> anyhow::Result<()> {
                 }
             } else {
                 // Last tab — exit server
-                if let Some(ref mut c) = client {
+                for c in &mut clients {
                     let _ = protocol::write_msg(&mut c.writer, protocol::S_EXIT, &[]);
                 }
                 break;
@@ -398,9 +492,10 @@ pub fn run(session_name: &str, args: &[String]) -> anyhow::Result<()> {
 
         // ── Accept new connections with handshake ──
         // Read the first message to determine intent:
-        //   C_PING  → respond with S_PONG, close (no side effects)
-        //   C_KILL  → kill server
-        //   C_RESIZE → real client attach (detach old client first)
+        //   C_PING   → respond with S_PONG, close (no side effects)
+        //   C_KILL   → kill server
+        //   C_RESIZE → legacy client attach (steal mode)
+        //   C_ATTACH → new protocol attach with mode
         if let Ok((conn, _)) = listener.accept() {
             conn.set_nonblocking(false).ok();
             // Short timeout for handshake — fail-close if setting fails
@@ -421,48 +516,52 @@ pub fn run(session_name: &str, args: &[String]) -> anyhow::Result<()> {
                         for pane in panes.values_mut() {
                             pane.kill();
                         }
-                        if let Some(ref mut c) = client {
+                        for c in &mut clients {
                             let _ = protocol::write_msg(&mut c.writer, protocol::S_EXIT, &[]);
                         }
                         session::cleanup(session_name);
                         ipc::cleanup();
                         return Ok(());
                     }
+                    Ok((protocol::C_ATTACH, payload)) => {
+                        // New protocol: attach with mode
+                        if let Ok(req) = serde_json::from_slice::<protocol::AttachRequest>(&payload)
+                        {
+                            accept_client(
+                                conn,
+                                req.cols,
+                                req.rows,
+                                req.mode,
+                                &mut clients,
+                                &mut panes,
+                                &layout,
+                                &settings,
+                                &mut tw,
+                                &mut th,
+                                &mut drag,
+                                zoomed_pane,
+                                &mut update,
+                            );
+                        }
+                    }
                     Ok((protocol::C_RESIZE, payload)) => {
-                        // Real client attach — detach old client first
-                        if let Some(ref mut old) = client {
-                            let _ = protocol::write_msg(&mut old.writer, protocol::S_DETACHED, &[]);
-                        }
-                        client = None;
-
-                        // Apply the initial terminal size
+                        // Legacy client attach — always steal mode
                         if let Some((w, h)) = protocol::decode_resize(&payload) {
-                            tw = w;
-                            th = h;
-                            drag = None;
-                            super::resize_all(&mut panes, &layout, tw, th, &settings);
-                            if let Some(zpid) = zoomed_pane {
-                                super::resize_zoomed_pane(&mut panes, zpid, tw, th, &settings);
-                            }
-                        }
-
-                        // Set up new client with a read timeout on the reader socket
-                        // so it doesn't block forever when client is replaced later
-                        if let Ok(read_conn) = conn.try_clone() {
-                            // No read timeout — client may be idle for long periods.
-                            // Thread exits when socket is closed (client disconnect).
-                            conn.set_read_timeout(None).ok();
-                            let (msg_tx, msg_rx) = mpsc::channel();
-                            std::thread::spawn(move || {
-                                client_reader(read_conn, msg_tx);
-                            });
-                            client = Some(ClientConn {
-                                writer: std::io::BufWriter::new(conn),
-                                event_rx: msg_rx,
-                            });
-                            // Force full redraw for new client
-                            update.mark_all(&layout);
-                            update.border_dirty = true;
+                            accept_client(
+                                conn,
+                                w,
+                                h,
+                                protocol::AttachMode::Steal,
+                                &mut clients,
+                                &mut panes,
+                                &layout,
+                                &settings,
+                                &mut tw,
+                                &mut th,
+                                &mut drag,
+                                zoomed_pane,
+                                &mut update,
+                            );
                         }
                     }
                     _ => {
@@ -472,15 +571,25 @@ pub fn run(session_name: &str, args: &[String]) -> anyhow::Result<()> {
             }
         }
 
-        // ── Process client events ──
-        let mut client_disconnected = false;
-        let mut detach_requested = false;
+        // ── Process client events from all clients ──
+        let mut detach_ids: Vec<u64> = Vec::new();
+        let mut disconnect_ids: Vec<u64> = Vec::new();
+        let mut kill_requested = false;
+        let mut detach_all = false; // Set by Ctrl+B d via process_key
         let mut tab_action = TabAction::None;
+        let mut size_changed = false;
         let current_tab_names = tab_mgr.tab_names(&tab_name);
-        if let Some(ref c) = client {
+
+        for client in &mut clients {
+            let client_mode = client.mode;
+            let client_id = client.id;
             loop {
-                match c.event_rx.try_recv() {
+                match client.event_rx.try_recv() {
                     Ok(ClientMsg::Event(event)) => {
+                        // Readonly clients cannot send input
+                        if client_mode == protocol::AttachMode::Readonly {
+                            continue;
+                        }
                         process_event(
                             event,
                             &mut mode,
@@ -501,50 +610,66 @@ pub fn run(session_name: &str, args: &[String]) -> anyhow::Result<()> {
                             th,
                             effective_scrollback,
                             &border_cache,
-                            &mut detach_requested,
+                            &mut detach_all,
                             &mut tab_action,
                             &current_tab_names,
                             prefix_key,
                         );
                     }
                     Ok(ClientMsg::Resize(w, h)) => {
-                        tw = w;
-                        th = h;
-                        drag = None;
-                        super::resize_all(&mut panes, &layout, tw, th, &settings);
-                        if let Some(zpid) = zoomed_pane {
-                            super::resize_zoomed_pane(&mut panes, zpid, tw, th, &settings);
-                        }
-                        update.mark_all(&layout);
-                        update.border_dirty = true;
+                        client.tw = w;
+                        client.th = h;
+                        size_changed = true;
                     }
                     Ok(ClientMsg::Detach) => {
-                        // Protocol-level detach request → send ack
-                        detach_requested = true;
+                        detach_ids.push(client_id);
                         break;
                     }
                     Ok(ClientMsg::Disconnected) => {
-                        client_disconnected = true;
+                        disconnect_ids.push(client_id);
                         break;
                     }
                     Ok(ClientMsg::Kill) => {
-                        // Kill all panes and exit
-                        for pane in panes.values_mut() {
-                            pane.kill();
-                        }
-                        if let Some(ref mut c) = client {
-                            let _ = protocol::write_msg(&mut c.writer, protocol::S_EXIT, &[]);
-                        }
-                        session::cleanup(session_name);
-                        ipc::cleanup();
-                        return Ok(());
+                        kill_requested = true;
+                        break;
                     }
                     Err(mpsc::TryRecvError::Empty) => break,
                     Err(mpsc::TryRecvError::Disconnected) => {
-                        client_disconnected = true;
+                        disconnect_ids.push(client_id);
                         break;
                     }
                 }
+            }
+            if kill_requested {
+                break;
+            }
+        }
+
+        if kill_requested {
+            for pane in panes.values_mut() {
+                pane.kill();
+            }
+            for c in &mut clients {
+                let _ = protocol::write_msg(&mut c.writer, protocol::S_EXIT, &[]);
+            }
+            session::cleanup(session_name);
+            ipc::cleanup();
+            return Ok(());
+        }
+
+        // Handle per-client resize
+        if size_changed {
+            let (ew, eh) = effective_size(&clients);
+            if ew != tw || eh != th {
+                tw = ew;
+                th = eh;
+                drag = None;
+                super::resize_all(&mut panes, &layout, tw, th, &settings);
+                if let Some(zpid) = zoomed_pane {
+                    super::resize_zoomed_pane(&mut panes, zpid, tw, th, &settings);
+                }
+                update.mark_all(&layout);
+                update.border_dirty = true;
             }
         }
 
@@ -556,13 +681,72 @@ pub fn run(session_name: &str, args: &[String]) -> anyhow::Result<()> {
             }
         }
 
-        if detach_requested {
-            if let Some(ref mut c) = client {
-                let _ = protocol::write_msg(&mut c.writer, protocol::S_DETACHED, &[]);
+        // detach_all (from Ctrl+B d): in steal mode, detach all clients.
+        // In shared/readonly mode, only detach writable clients (the ones that
+        // could have triggered the detach).
+        if detach_all {
+            for c in &clients {
+                if c.mode != protocol::AttachMode::Readonly {
+                    detach_ids.push(c.id);
+                }
             }
-            client = None;
-        } else if client_disconnected {
-            client = None;
+        }
+
+        // Handle detach/disconnect — auto-save when last client leaves
+        let had_clients = !clients.is_empty();
+        for id in &detach_ids {
+            if let Some(pos) = clients.iter().position(|c| c.id == *id) {
+                let _ = protocol::write_msg(&mut clients[pos].writer, protocol::S_DETACHED, &[]);
+                clients.remove(pos);
+            }
+        }
+        for id in &disconnect_ids {
+            if let Some(pos) = clients.iter().position(|c| c.id == *id) {
+                clients.remove(pos);
+            }
+        }
+        // Recompute effective size after any client changes
+        if !detach_ids.is_empty() || !disconnect_ids.is_empty() {
+            let (ew, eh) = effective_size(&clients);
+            if ew != tw || eh != th {
+                tw = ew;
+                th = eh;
+                drag = None;
+                super::resize_all(&mut panes, &layout, tw, th, &settings);
+                if let Some(zpid) = zoomed_pane {
+                    super::resize_zoomed_pane(&mut panes, zpid, tw, th, &settings);
+                }
+                update.mark_all(&layout);
+                update.border_dirty = true;
+            }
+        }
+
+        if had_clients
+            && clients.is_empty()
+            && (!detach_ids.is_empty() || !disconnect_ids.is_empty())
+        {
+            // All clients gone — auto-save and reset input state
+            let snapshot = WorkspaceSnapshot::from_live(
+                &tab_mgr,
+                &tab_name,
+                &layout,
+                &panes,
+                active,
+                zoomed_pane,
+                broadcast,
+                &restart_policies,
+                &default_shell,
+                settings.border_style,
+                settings.show_status_bar,
+                settings.show_tab_bar,
+                effective_scrollback,
+            );
+            workspace::auto_save(session_name, &snapshot);
+            mode = InputMode::Normal;
+            drag = None;
+            selection_anchor = None;
+            text_selection = None;
+            last_click = None;
         }
 
         // ── Handle tab actions ──
@@ -617,6 +801,7 @@ pub fn run(session_name: &str, args: &[String]) -> anyhow::Result<()> {
                         ));
                         update.mark_all(&layout);
                         update.border_dirty = true;
+                        tab_names_dirty = true;
                     }
                     Err(_) => {
                         // Spawn failed — revert: close this empty tab and restore previous
@@ -639,6 +824,7 @@ pub fn run(session_name: &str, args: &[String]) -> anyhow::Result<()> {
                             ));
                             update.mark_all(&layout);
                             update.border_dirty = true;
+                            tab_names_dirty = true;
                         }
                     }
                 }
@@ -688,6 +874,7 @@ pub fn run(session_name: &str, args: &[String]) -> anyhow::Result<()> {
                         ));
                         update.mark_all(&layout);
                         update.border_dirty = true;
+                        tab_names_dirty = true;
                     }
                 }
             }
@@ -720,18 +907,20 @@ pub fn run(session_name: &str, args: &[String]) -> anyhow::Result<()> {
                         ));
                         update.mark_all(&layout);
                         update.border_dirty = true;
+                        tab_names_dirty = true;
                     }
                 }
             }
             TabAction::Rename(new_name) => {
                 tab_name = new_name;
                 update.full_redraw = true;
+                tab_names_dirty = true;
             }
             TabAction::KillSession => {
                 // Kill all panes in all tabs
                 super::kill_all_panes(&mut panes);
                 tab_mgr.kill_all_inactive();
-                if let Some(ref mut c) = client {
+                for c in &mut clients {
                     let _ = protocol::write_msg(&mut c.writer, protocol::S_EXIT, &[]);
                 }
                 session::cleanup(session_name);
@@ -744,6 +933,105 @@ pub fn run(session_name: &str, args: &[String]) -> anyhow::Result<()> {
         // ── Handle IPC commands ──
         if let Some(ref rx) = ipc_rx {
             while let Ok((cmd, resp_tx)) = rx.try_recv() {
+                // Intercept Save/Load to use full-session snapshots (with all tabs)
+                if let ipc::IpcRequest::Save { ref path } = cmd {
+                    let snapshot = WorkspaceSnapshot::from_live(
+                        &tab_mgr,
+                        &tab_name,
+                        &layout,
+                        &panes,
+                        active,
+                        zoomed_pane,
+                        broadcast,
+                        &restart_policies,
+                        &default_shell,
+                        settings.border_style,
+                        settings.show_status_bar,
+                        settings.show_tab_bar,
+                        effective_scrollback,
+                    );
+                    let response = match workspace::save_snapshot(path, &snapshot) {
+                        Ok(()) => ipc::IpcResponse::success(format!("saved {}", path)),
+                        Err(error) => ipc::IpcResponse::error(error.to_string()),
+                    };
+                    let _ = resp_tx.send(response);
+                    continue;
+                }
+
+                // Intercept Load for full-session restore (all tabs)
+                if let ipc::IpcRequest::Load { ref path } = cmd {
+                    let load_result: anyhow::Result<()> = (|| {
+                        let snapshot = workspace::load_snapshot(path)?;
+                        let snap_scrollback = snapshot.scrollback;
+
+                        // Kill current session
+                        super::kill_all_panes(&mut panes);
+                        tab_mgr.kill_all_inactive();
+
+                        default_shell = snapshot.shell.clone();
+                        settings = Settings::new(snapshot.border_style);
+                        settings.show_status_bar = snapshot.show_status_bar;
+                        settings.show_tab_bar = snapshot.show_tab_bar;
+
+                        // Spawn all tabs in order
+                        let mut all_tabs: Vec<Tab> = Vec::new();
+                        for tab_snap in &snapshot.tabs {
+                            let tp = super::spawn_snapshot_panes(
+                                &tab_snap.layout,
+                                tab_snap,
+                                &default_shell,
+                                tw,
+                                th,
+                                &settings,
+                                snap_scrollback,
+                            )?;
+                            let mut tr = HashMap::new();
+                            for ps in &tab_snap.panes {
+                                if ps.restart != project::RestartPolicy::Never {
+                                    tr.insert(ps.id, ps.restart.clone());
+                                }
+                            }
+                            let mut tab = Tab::new(
+                                tab_snap.name.clone(),
+                                tab_snap.layout.clone(),
+                                tp,
+                                tab_snap.active_pane,
+                            );
+                            tab.restart_policies = tr;
+                            tab.zoomed_pane = tab_snap.zoomed_pane;
+                            tab.broadcast = tab_snap.broadcast;
+                            all_tabs.push(tab);
+                        }
+
+                        let (new_mgr, active_tab) =
+                            TabManager::from_tabs(all_tabs, snapshot.active_tab);
+                        tab_mgr = new_mgr;
+                        tab_name = active_tab.name;
+                        layout = active_tab.layout;
+                        panes = active_tab.panes;
+                        active = active_tab.active_pane;
+                        restart_policies = active_tab.restart_policies;
+                        restart_state = active_tab.restart_state;
+                        zoomed_pane = active_tab.zoomed_pane;
+                        broadcast = active_tab.broadcast;
+                        tab_names_dirty = true;
+                        Ok(())
+                    })();
+
+                    match load_result {
+                        Ok(()) => {
+                            update.mark_all(&layout);
+                            update.border_dirty = true;
+                            let _ =
+                                resp_tx.send(ipc::IpcResponse::success(format!("loaded {}", path)));
+                        }
+                        Err(e) => {
+                            let _ = resp_tx.send(ipc::IpcResponse::error(e.to_string()));
+                        }
+                    }
+                    continue;
+                }
+
                 let (response, mut ipc_update) = super::handle_ipc_command(
                     cmd,
                     &mut layout,
@@ -776,62 +1064,89 @@ pub fn run(session_name: &str, args: &[String]) -> anyhow::Result<()> {
             super::resize_zoomed_pane(&mut panes, active, tw, th, &settings);
         }
 
-        if update.needs_render() {
-            if let Some(ref mut c) = client {
-                if let Some(ref cache) = border_cache {
-                    // Sync scrollback
-                    for pane in panes.values_mut() {
-                        pane.sync_scrollback();
-                    }
-
-                    render_buf.clear();
-                    let tabs = tab_mgr.tab_names(&tab_name);
-                    let render_result = render_frame_to_buf(
-                        &mut render_buf,
-                        &panes,
-                        &layout,
-                        active,
-                        &settings,
-                        tw,
-                        th,
-                        drag.is_some(),
-                        cache,
-                        &update.dirty_panes,
-                        update.full_redraw,
-                        &mode,
-                        broadcast,
-                        &text_selection,
-                        zoomed_pane,
-                        &default_shell,
-                        &tabs,
-                    );
-
-                    // Reset scrollback
-                    for pane in panes.values_mut() {
-                        pane.reset_scrollback_view();
-                    }
-
-                    if render_result.is_ok()
-                        && !render_buf.is_empty()
-                        && protocol::write_msg(&mut c.writer, protocol::S_OUTPUT, &render_buf)
-                            .is_err()
-                    {
-                        client = None;
-                    }
+        let render_needed = update.needs_render();
+        if render_needed && !clients.is_empty() {
+            if let Some(ref cache) = border_cache {
+                if tab_names_dirty {
+                    tab_names_cache = tab_mgr.tab_names(&tab_name);
+                    tab_names_dirty = false;
                 }
-            } else {
-                // No client — just reset scrollback
-                for pane in panes.values_mut() {
-                    pane.sync_scrollback();
-                    pane.reset_scrollback_view();
+
+                let sel_for_render = text_selection.as_ref().map(|s| {
+                    let (sr, sc, er, ec) = s.normalized();
+                    (s.pane_id, sr, sc, er, ec)
+                });
+                let needs_selection_chars =
+                    zoomed_pane.is_none() && settings.show_status_bar && text_selection.is_some();
+                let render_targets = super::collect_render_targets(
+                    &panes,
+                    &update.dirty_panes,
+                    update.full_redraw,
+                    zoomed_pane,
+                    needs_selection_chars
+                        .then(|| text_selection.as_ref().map(|s| s.pane_id))
+                        .flatten(),
+                );
+                super::sync_render_targets(&mut panes, &render_targets);
+                let selection_chars = if needs_selection_chars {
+                    super::selection_char_count_from_synced(&panes, sel_for_render)
+                } else {
+                    0
+                };
+
+                // Render once (smallest-client policy: all clients see the same frame)
+                render_buf.clear();
+                let render_result = render_frame_to_buf(
+                    &mut render_buf,
+                    &panes,
+                    &layout,
+                    active,
+                    &settings,
+                    tw,
+                    th,
+                    drag.is_some(),
+                    cache,
+                    &update.dirty_panes,
+                    update.full_redraw,
+                    &mode,
+                    broadcast,
+                    sel_for_render,
+                    selection_chars,
+                    zoomed_pane,
+                    &default_shell,
+                    &tab_names_cache,
+                );
+
+                super::reset_render_targets(&mut panes, &render_targets);
+
+                // Broadcast frame to all clients; remove failed ones
+                if render_result.is_ok() && !render_buf.is_empty() {
+                    clients.retain_mut(|c| {
+                        if protocol::write_msg(&mut c.writer, protocol::S_OUTPUT, &render_buf)
+                            .is_err()
+                        {
+                            // Try to send detach ack before dropping
+                            let _ = protocol::write_msg(&mut c.writer, protocol::S_DETACHED, &[]);
+                            false
+                        } else {
+                            true
+                        }
+                    });
                 }
             }
         }
 
         // Block until any event source wakes us, or timeout.
-        // With client: 8ms max (frame budget for smooth rendering).
+        // With clients: 2ms when we just rendered (active I/O), 8ms idle.
         // Headless: 20ms (responsive to PING probes for session discovery).
-        let timeout_ms = if client.is_some() { 8 } else { 20 };
+        let rendered_this_frame = render_needed;
+        let timeout_ms = if clients.is_empty() {
+            20
+        } else if rendered_this_frame {
+            2
+        } else {
+            8
+        };
         let _ = wake_rx.recv_timeout(Duration::from_millis(timeout_ms));
         // Drain accumulated wake signals
         while wake_rx.try_recv().is_ok() {}
@@ -874,6 +1189,66 @@ fn client_reader(stream: UnixStream, tx: mpsc::Sender<ClientMsg>) {
     }
 }
 
+/// Accept a new client connection, handling steal/shared/readonly modes.
+#[allow(clippy::too_many_arguments)]
+fn accept_client(
+    conn: UnixStream,
+    new_w: u16,
+    new_h: u16,
+    mode: protocol::AttachMode,
+    clients: &mut Vec<ConnectedClient>,
+    panes: &mut HashMap<usize, Pane>,
+    layout: &Layout,
+    settings: &Settings,
+    tw: &mut u16,
+    th: &mut u16,
+    drag: &mut Option<DragState>,
+    zoomed_pane: Option<usize>,
+    update: &mut RenderUpdate,
+) {
+    // Steal mode: detach all existing clients
+    if mode == protocol::AttachMode::Steal {
+        for c in clients.iter_mut() {
+            let _ = protocol::write_msg(&mut c.writer, protocol::S_DETACHED, &[]);
+        }
+        clients.clear();
+    }
+
+    // Set up the new client
+    if let Ok(read_conn) = conn.try_clone() {
+        conn.set_read_timeout(None).ok();
+        let (msg_tx, msg_rx) = mpsc::channel();
+        std::thread::spawn(move || {
+            client_reader(read_conn, msg_tx);
+        });
+        let client_id = NEXT_CLIENT_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        clients.push(ConnectedClient {
+            id: client_id,
+            writer: std::io::BufWriter::new(conn),
+            event_rx: msg_rx,
+            mode,
+            tw: new_w,
+            th: new_h,
+        });
+    }
+
+    // Recompute effective size and resize panes
+    let (ew, eh) = effective_size(clients);
+    if ew != *tw || eh != *th {
+        *tw = ew;
+        *th = eh;
+        *drag = None;
+        super::resize_all(panes, layout, *tw, *th, settings);
+        if let Some(zpid) = zoomed_pane {
+            super::resize_zoomed_pane(panes, zpid, *tw, *th, settings);
+        }
+    }
+
+    // Force full redraw for new client
+    update.mark_all(layout);
+    update.border_dirty = true;
+}
+
 /// Render a full frame to a byte buffer (instead of stdout).
 #[allow(clippy::too_many_arguments)]
 fn render_frame_to_buf(
@@ -890,7 +1265,8 @@ fn render_frame_to_buf(
     full_redraw: bool,
     mode: &InputMode,
     broadcast: bool,
-    text_selection: &Option<TextSelection>,
+    selection: render::PaneSelection,
+    selection_chars: usize,
     zoomed_pane: Option<usize>,
     default_shell: &str,
     tab_names: &[(usize, String, bool)],
@@ -912,8 +1288,8 @@ fn render_frame_to_buf(
 
     if let Some(zpid) = zoomed_pane {
         queue!(buf, terminal::BeginSynchronizedUpdate)?;
-        let ids = layout.pane_ids();
-        let pane_idx = ids.iter().position(|&id| id == zpid).unwrap_or(0);
+        let pane_order = border_cache.pane_order();
+        let pane_idx = pane_order.iter().position(|&id| id == zpid).unwrap_or(0);
         let label = panes
             .get(&zpid)
             .map(|p| p.launch_label(default_shell))
@@ -942,7 +1318,7 @@ fn render_frame_to_buf(
                 tw,
                 th,
                 pane_idx,
-                ids.len(),
+                pane_order.len(),
                 zoom_label,
                 pane_name,
                 0,
@@ -950,27 +1326,6 @@ fn render_frame_to_buf(
         }
         queue!(buf, terminal::EndSynchronizedUpdate)?;
     } else {
-        let sel_for_render = text_selection.as_ref().map(|s| {
-            let (sr, sc, er, ec) = s.normalized();
-            (s.pane_id, sr, sc, er, ec)
-        });
-        let sel_chars = text_selection
-            .as_ref()
-            .and_then(|sel| {
-                panes.get(&sel.pane_id).map(|pane| {
-                    let text = super::extract_selected_text(
-                        pane.screen(),
-                        sel.pane_id,
-                        sel.start_row,
-                        sel.start_col,
-                        sel.end_row,
-                        sel.end_col,
-                    );
-                    text.chars().count()
-                })
-            })
-            .unwrap_or(0);
-
         queue!(buf, terminal::BeginSynchronizedUpdate)?;
         render::render_panes(
             buf,
@@ -985,7 +1340,7 @@ fn render_frame_to_buf(
             border_cache,
             dirty_panes,
             full_redraw,
-            sel_for_render,
+            selection,
             broadcast,
         )?;
         let is_text_input = matches!(
@@ -993,30 +1348,33 @@ fn render_frame_to_buf(
             InputMode::RenameTab { .. } | InputMode::CommandPalette { .. }
         );
         // Status bar (skip if text input mode will draw over it)
-        if !is_text_input && settings.show_status_bar && (!mode_label.is_empty() || sel_chars > 0) {
-            let ids = layout.pane_ids();
-            let active_idx = ids.iter().position(|&id| id == active).unwrap_or(0);
+        if !is_text_input
+            && settings.show_status_bar
+            && (!mode_label.is_empty() || selection_chars > 0)
+        {
+            let pane_order = border_cache.pane_order();
+            let active_idx = pane_order.iter().position(|&id| id == active).unwrap_or(0);
             let pane_name = panes.get(&active).and_then(|p| p.name()).unwrap_or("");
             render::draw_status_bar_full(
                 buf,
                 tw,
                 th,
                 active_idx,
-                ids.len(),
+                pane_order.len(),
                 mode_label,
                 pane_name,
-                sel_chars,
+                selection_chars,
             )?;
         }
         if settings.visible {
-            settings.render_overlay(buf, tw, th)?;
+            settings.render_overlay(buf, tw, th, broadcast)?;
             queue!(buf, cursor::Hide)?;
         }
         queue!(buf, terminal::EndSynchronizedUpdate)?;
     }
 
-    // Tab bar (only when multiple tabs exist)
-    if tab_names.len() > 1 {
+    // Tab bar (only when multiple tabs exist and show_tab_bar is enabled)
+    if tab_names.len() > 1 && settings.show_tab_bar {
         render::draw_tab_bar(buf, tw, th, tab_names, settings.show_status_bar)?;
     }
 
@@ -1655,44 +2013,15 @@ fn process_key(
     } else if settings.visible {
         let prev_border = settings.border_style;
         let prev_status = settings.show_status_bar;
+        let prev_tab_bar = settings.show_tab_bar;
         let action = settings.handle_key(key);
-        match action {
-            SettingsAction::SplitH => {
-                let _ = super::do_split(
-                    layout,
-                    panes,
-                    *active,
-                    Direction::Horizontal,
-                    default_shell,
-                    tw,
-                    th,
-                    settings,
-                    scrollback,
-                );
-                update.mark_all(layout);
-                update.border_dirty = true;
-            }
-            SettingsAction::SplitV => {
-                let _ = super::do_split(
-                    layout,
-                    panes,
-                    *active,
-                    Direction::Vertical,
-                    default_shell,
-                    tw,
-                    th,
-                    settings,
-                    scrollback,
-                );
-                update.mark_all(layout);
-                update.border_dirty = true;
-            }
-            _ => {}
+        if action == SettingsAction::BroadcastToggle {
+            *broadcast = !*broadcast;
         }
         if settings.border_style != prev_border {
             update.full_redraw = true;
         }
-        if settings.show_status_bar != prev_status {
+        if settings.show_status_bar != prev_status || settings.show_tab_bar != prev_tab_bar {
             super::resize_all(panes, layout, tw, th, settings);
             update.border_dirty = true;
             update.mark_all(layout);
@@ -1760,21 +2089,29 @@ fn process_key(
             }
         }
     } else if key.code == KeyCode::Enter && panes.get(active).is_some_and(|p| !p.is_alive()) {
-        let launch = panes
+        let (launch, old_name, pane_shell) = panes
             .get(active)
-            .map(|p| p.launch().clone())
-            .unwrap_or(PaneLaunch::Shell);
-        let _ = super::replace_pane(
-            panes,
-            layout,
-            *active,
-            launch,
-            default_shell,
-            tw,
-            th,
-            settings,
-            scrollback,
-        );
+            .map(|p| {
+                (
+                    p.launch().clone(),
+                    p.name().map(String::from),
+                    p.initial_shell().map(String::from),
+                )
+            })
+            .unwrap_or((PaneLaunch::Shell, None, None));
+        let eff_shell = pane_shell.as_deref().unwrap_or(default_shell);
+        if super::replace_pane(
+            panes, layout, *active, launch, eff_shell, tw, th, settings, scrollback,
+        )
+        .is_ok()
+        {
+            if let Some(pane) = panes.get_mut(active) {
+                pane.set_name(old_name);
+                if let Some(ref s) = pane_shell {
+                    pane.set_initial_shell(Some(s.clone()));
+                }
+            }
+        }
         update.dirty_panes.insert(*active);
     } else if *broadcast {
         for pane in panes.values_mut() {
@@ -1968,49 +2305,24 @@ fn process_mouse(
             if settings.visible {
                 let prev_border = settings.border_style;
                 let prev_status = settings.show_status_bar;
+                let prev_tab_bar = settings.show_tab_bar;
                 let action = settings.handle_click(mouse.column, mouse.row, tw, th);
-                match action {
-                    SettingsAction::SplitH => {
-                        let _ = super::do_split(
-                            layout,
-                            panes,
-                            *active,
-                            Direction::Horizontal,
-                            default_shell,
-                            tw,
-                            th,
-                            settings,
-                            scrollback,
-                        );
-                        update.mark_all(layout);
-                        update.border_dirty = true;
-                    }
-                    SettingsAction::SplitV => {
-                        let _ = super::do_split(
-                            layout,
-                            panes,
-                            *active,
-                            Direction::Vertical,
-                            default_shell,
-                            tw,
-                            th,
-                            settings,
-                            scrollback,
-                        );
-                        update.mark_all(layout);
-                        update.border_dirty = true;
-                    }
-                    SettingsAction::Changed | SettingsAction::Close | SettingsAction::None => {}
+                if action == SettingsAction::BroadcastToggle {
+                    *broadcast = !*broadcast;
                 }
                 if settings.border_style != prev_border {
                     update.full_redraw = true;
                 }
-                if settings.show_status_bar != prev_status {
+                if settings.show_status_bar != prev_status || settings.show_tab_bar != prev_tab_bar
+                {
                     super::resize_all(panes, layout, tw, th, settings);
                     update.border_dirty = true;
                     update.mark_all(layout);
                 }
-                if action == SettingsAction::Changed || action == SettingsAction::Close {
+                if action == SettingsAction::Changed
+                    || action == SettingsAction::Close
+                    || action == SettingsAction::BroadcastToggle
+                {
                     update.full_redraw = true;
                 }
             } else if let Some(action) =

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -19,18 +19,17 @@ const Y_I0: u16 = 5; // Single
 const Y_I1: u16 = 6; // Rounded
 const Y_I2: u16 = 7; // Heavy
 const Y_I3: u16 = 8; // Double
-const Y_DIV1: u16 = 9;
-const Y_SEC2: u16 = 10; // "PANE"
-const Y_I4: u16 = 11; // Split H
-const Y_I5: u16 = 12; // Split V
-const Y_DIV2: u16 = 13;
-const Y_SEC3: u16 = 14; // "DISPLAY"
-const Y_I6: u16 = 15; // Status Bar
-const Y_DIV3: u16 = 16;
-const Y_I7: u16 = 17; // Close
+const Y_I4: u16 = 9; // None
+const Y_DIV1: u16 = 10;
+const Y_SEC2: u16 = 11; // "DISPLAY"
+const Y_I5: u16 = 12; // Status Bar
+const Y_I6: u16 = 13; // Tab Bar
+const Y_I7: u16 = 14; // Broadcast
+const Y_DIV2: u16 = 15;
+const Y_I8: u16 = 16; // Close
 
-const ITEM_Y: [u16; 8] = [Y_I0, Y_I1, Y_I2, Y_I3, Y_I4, Y_I5, Y_I6, Y_I7];
-const ITEM_COUNT: usize = 8;
+const ITEM_Y: [u16; 9] = [Y_I0, Y_I1, Y_I2, Y_I3, Y_I4, Y_I5, Y_I6, Y_I7, Y_I8];
+const ITEM_COUNT: usize = 9;
 
 // ─── Colors ────────────────────────────────────────────
 
@@ -81,10 +80,11 @@ const I_SINGLE: usize = 0;
 const I_ROUNDED: usize = 1;
 const I_HEAVY: usize = 2;
 const I_DOUBLE: usize = 3;
-const I_SPLIT_H: usize = 4;
-const I_SPLIT_V: usize = 5;
-const I_STATUS: usize = 6;
-const I_CLOSE: usize = 7;
+const I_NONE: usize = 4;
+const I_STATUS: usize = 5;
+const I_TAB_BAR: usize = 6;
+const I_BROADCAST: usize = 7;
+const I_CLOSE: usize = 8;
 
 // ─── State ─────────────────────────────────────────────
 
@@ -92,6 +92,7 @@ pub struct Settings {
     pub visible: bool,
     pub border_style: BorderStyle,
     pub show_status_bar: bool,
+    pub show_tab_bar: bool,
     focused: usize,
 }
 
@@ -100,8 +101,7 @@ pub enum SettingsAction {
     None,
     Close,
     Changed,
-    SplitH,
-    SplitV,
+    BroadcastToggle,
 }
 
 impl Settings {
@@ -110,6 +110,7 @@ impl Settings {
             visible: false,
             border_style: border,
             show_status_bar: true,
+            show_tab_bar: true,
             focused: I_ROUNDED,
         }
     }
@@ -122,7 +123,7 @@ impl Settings {
                 BorderStyle::Rounded => I_ROUNDED,
                 BorderStyle::Heavy => I_HEAVY,
                 BorderStyle::Double => I_DOUBLE,
-                BorderStyle::None => I_SINGLE, // default focus position
+                BorderStyle::None => I_NONE,
             };
         }
     }
@@ -147,6 +148,7 @@ impl Settings {
             KeyCode::Char('2') => self.set_border(BorderStyle::Rounded, I_ROUNDED),
             KeyCode::Char('3') => self.set_border(BorderStyle::Heavy, I_HEAVY),
             KeyCode::Char('4') => self.set_border(BorderStyle::Double, I_DOUBLE),
+            KeyCode::Char('5') => self.set_border(BorderStyle::None, I_NONE),
             KeyCode::Enter | KeyCode::Char(' ') => self.activate(self.focused),
             _ => SettingsAction::None,
         }
@@ -169,7 +171,13 @@ impl Settings {
 
     // ─── Render ────────────────────────────────────────
 
-    pub fn render_overlay(&self, stdout: &mut impl Write, tw: u16, th: u16) -> anyhow::Result<()> {
+    pub fn render_overlay(
+        &self,
+        stdout: &mut impl Write,
+        tw: u16,
+        th: u16,
+        broadcast: bool,
+    ) -> anyhow::Result<()> {
         if tw < W + 4 || th < H + 2 {
             return Ok(());
         }
@@ -206,7 +214,7 @@ impl Settings {
             BG,
             DIM_FG,
             false,
-            "j/k move  Enter apply  1-4 border  q close",
+            "j/k move  Enter apply  1-5 border  q close",
         )?;
 
         // Section: Border Style
@@ -223,20 +231,25 @@ impl Settings {
         )?;
         self.item_border(stdout, x, xr, oy, I_HEAVY, "Heavy", BorderStyle::Heavy)?;
         self.item_border(stdout, x, xr, oy, I_DOUBLE, "Double", BorderStyle::Double)?;
-
-        // Divider + Section: Pane
-        div(stdout, x, oy + Y_DIV1, inner_w)?;
-        text(stdout, x, oy + Y_SEC2, BG, SEC_FG, true, "PANE")?;
-        self.item_action(stdout, x, xr, oy, I_SPLIT_H, "Split Left | Right", "Ctrl+D")?;
-        self.item_action(stdout, x, xr, oy, I_SPLIT_V, "Split Top / Bottom", "Ctrl+E")?;
+        self.item_border(stdout, x, xr, oy, I_NONE, "None", BorderStyle::None)?;
 
         // Divider + Section: Display
-        div(stdout, x, oy + Y_DIV2, inner_w)?;
-        text(stdout, x, oy + Y_SEC3, BG, SEC_FG, true, "DISPLAY")?;
-        self.item_toggle(stdout, x, xr, oy)?;
+        div(stdout, x, oy + Y_DIV1, inner_w)?;
+        text(stdout, x, oy + Y_SEC2, BG, SEC_FG, true, "DISPLAY")?;
+        self.item_toggle(
+            stdout,
+            x,
+            xr,
+            oy,
+            I_STATUS,
+            "Status Bar",
+            self.show_status_bar,
+        )?;
+        self.item_toggle(stdout, x, xr, oy, I_TAB_BAR, "Tab Bar", self.show_tab_bar)?;
+        self.item_toggle(stdout, x, xr, oy, I_BROADCAST, "Broadcast", broadcast)?;
 
         // Divider + Close
-        div(stdout, x, oy + Y_DIV3, inner_w)?;
+        div(stdout, x, oy + Y_DIV2, inner_w)?;
         self.item_close(stdout, x, xr, oy)?;
 
         queue!(stdout, ResetColor, SetAttribute(Attribute::Reset))?;
@@ -294,15 +307,15 @@ impl Settings {
     }
 
     #[allow(clippy::too_many_arguments)]
-    fn item_action(
+    fn item_toggle(
         &self,
         stdout: &mut impl Write,
         x: u16,
         xr: u16,
         oy: u16,
         item: usize,
-        name: &str,
-        hint: &str,
+        label: &str,
+        value: bool,
     ) -> anyhow::Result<()> {
         let y = oy + ITEM_Y[item];
         let f = self.focused == item;
@@ -323,41 +336,12 @@ impl Settings {
         if f {
             queue!(stdout, SetAttribute(Attribute::Bold))?;
         }
-        queue!(stdout, Print(name))?;
+        queue!(stdout, Print(label))?;
         if f {
             queue!(stdout, SetAttribute(Attribute::Reset))?;
         }
 
-        right_tag(stdout, xr, y, bg, DIM_FG, hint)?;
-        Ok(())
-    }
-
-    fn item_toggle(&self, stdout: &mut impl Write, x: u16, xr: u16, oy: u16) -> anyhow::Result<()> {
-        let y = oy + ITEM_Y[I_STATUS];
-        let f = self.focused == I_STATUS;
-        let bg = if f { FOCUS_BG } else { BG };
-
-        row_bg(stdout, x - 1, y, (xr - x + 2) as usize, bg)?;
-        if f {
-            focus_marker(stdout, x - 1, y)?;
-        }
-
-        let nx = if f { x + 3 } else { x + 1 };
-        queue!(
-            stdout,
-            cursor::MoveTo(nx, y),
-            SetBackgroundColor(bg),
-            SetForegroundColor(if f { Color::White } else { LBL_FG }),
-        )?;
-        if f {
-            queue!(stdout, SetAttribute(Attribute::Bold))?;
-        }
-        queue!(stdout, Print("Status Bar"))?;
-        if f {
-            queue!(stdout, SetAttribute(Attribute::Reset))?;
-        }
-
-        let (tag, tag_fg) = if self.show_status_bar {
+        let (tag, tag_fg) = if value {
             ("ON", ACCENT)
         } else {
             ("OFF", DIM_FG)
@@ -399,15 +383,16 @@ impl Settings {
 
     fn adjust(&mut self, delta: isize) -> SettingsAction {
         match self.focused {
-            I_SINGLE | I_ROUNDED | I_HEAVY | I_DOUBLE => {
+            I_SINGLE | I_ROUNDED | I_HEAVY | I_DOUBLE | I_NONE => {
                 let o = [
                     BorderStyle::Single,
                     BorderStyle::Rounded,
                     BorderStyle::Heavy,
                     BorderStyle::Double,
+                    BorderStyle::None,
                 ];
                 let i = o.iter().position(|s| *s == self.border_style).unwrap_or(1);
-                let n = ((i as isize + delta).rem_euclid(4)) as usize;
+                let n = ((i as isize + delta).rem_euclid(5)) as usize;
                 self.border_style = o[n];
                 self.focused = n;
                 SettingsAction::Changed
@@ -416,6 +401,11 @@ impl Settings {
                 self.show_status_bar = !self.show_status_bar;
                 SettingsAction::Changed
             }
+            I_TAB_BAR => {
+                self.show_tab_bar = !self.show_tab_bar;
+                SettingsAction::Changed
+            }
+            I_BROADCAST => SettingsAction::BroadcastToggle,
             _ => SettingsAction::None,
         }
     }
@@ -426,18 +416,16 @@ impl Settings {
             I_ROUNDED => self.set_border(BorderStyle::Rounded, I_ROUNDED),
             I_HEAVY => self.set_border(BorderStyle::Heavy, I_HEAVY),
             I_DOUBLE => self.set_border(BorderStyle::Double, I_DOUBLE),
-            I_SPLIT_H => {
-                self.visible = false;
-                SettingsAction::SplitH
-            }
-            I_SPLIT_V => {
-                self.visible = false;
-                SettingsAction::SplitV
-            }
+            I_NONE => self.set_border(BorderStyle::None, I_NONE),
             I_STATUS => {
                 self.show_status_bar = !self.show_status_bar;
                 SettingsAction::Changed
             }
+            I_TAB_BAR => {
+                self.show_tab_bar = !self.show_tab_bar;
+                SettingsAction::Changed
+            }
+            I_BROADCAST => SettingsAction::BroadcastToggle,
             I_CLOSE => {
                 self.visible = false;
                 SettingsAction::Close

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -66,6 +66,24 @@ impl TabManager {
         }
     }
 
+    /// Build a TabManager from an ordered list of tabs, with one designated as active.
+    /// The active tab is removed from the list and returned for the caller to unpack.
+    /// All other tabs go into storage in their original order.
+    pub fn from_tabs(mut tabs: Vec<Tab>, active_idx: usize) -> (Self, Tab) {
+        assert!(!tabs.is_empty());
+        let active_idx = active_idx.min(tabs.len() - 1);
+        let active_tab = tabs.remove(active_idx);
+        let count = tabs.len() + 1; // +1 for the unpacked active tab
+        let next_id = count + 1;
+        let mgr = Self {
+            tabs,
+            active_idx,
+            count,
+            next_id,
+        };
+        (mgr, active_tab)
+    }
+
     /// Save the currently active tab's state and switch to a different tab.
     /// Returns the target tab's state to be unpacked by the caller.
     pub fn switch_to(&mut self, target_idx: usize, current: Tab) -> Option<Tab> {
@@ -157,6 +175,22 @@ impl TabManager {
                 pane.kill();
             }
         }
+    }
+
+    /// Get an inactive tab by its logical index.
+    /// Returns `None` if the index is the active tab or out of bounds.
+    pub fn get_inactive(&self, logical_idx: usize) -> Option<&Tab> {
+        if logical_idx == self.active_idx || logical_idx >= self.count {
+            return None;
+        }
+        // Storage has count-1 elements with a gap at active_idx.
+        // Logical indices below active_idx map directly; those above map to (idx - 1).
+        let storage_idx = if logical_idx < self.active_idx {
+            logical_idx
+        } else {
+            logical_idx - 1
+        };
+        self.tabs.get(storage_idx)
     }
 
     /// Get all tab names in order. The active tab is marked with index.
@@ -344,5 +378,52 @@ mod tests {
         let names = mgr.tab_names("active-0");
         assert_eq!(names[0], (0, "active-0".to_string(), true));
         assert_eq!(names[1], (1, "B-saved".to_string(), false));
+    }
+
+    #[test]
+    fn from_tabs_preserves_order() {
+        let tabs = vec![dummy_tab("A"), dummy_tab("B"), dummy_tab("C")];
+        let (mgr, active) = TabManager::from_tabs(tabs, 1); // B is active
+        assert_eq!(active.name, "B");
+        assert_eq!(mgr.count, 3);
+        assert_eq!(mgr.active_idx, 1);
+
+        // Verify tab order: A at 0, B (unpacked), C at 2
+        let names = mgr.tab_names("B");
+        assert_eq!(names[0], (0, "A".to_string(), false));
+        assert_eq!(names[1], (1, "B".to_string(), true));
+        assert_eq!(names[2], (2, "C".to_string(), false));
+    }
+
+    #[test]
+    fn from_tabs_active_at_zero() {
+        let tabs = vec![dummy_tab("X"), dummy_tab("Y")];
+        let (mgr, active) = TabManager::from_tabs(tabs, 0);
+        assert_eq!(active.name, "X");
+        assert_eq!(mgr.active_idx, 0);
+        let names = mgr.tab_names("X");
+        assert_eq!(names[0], (0, "X".to_string(), true));
+        assert_eq!(names[1], (1, "Y".to_string(), false));
+    }
+
+    #[test]
+    fn from_tabs_active_at_last() {
+        let tabs = vec![dummy_tab("A"), dummy_tab("B"), dummy_tab("C")];
+        let (mgr, active) = TabManager::from_tabs(tabs, 2);
+        assert_eq!(active.name, "C");
+        assert_eq!(mgr.active_idx, 2);
+        let names = mgr.tab_names("C");
+        assert_eq!(names[0], (0, "A".to_string(), false));
+        assert_eq!(names[1], (1, "B".to_string(), false));
+        assert_eq!(names[2], (2, "C".to_string(), true));
+    }
+
+    #[test]
+    fn from_tabs_single() {
+        let tabs = vec![dummy_tab("only")];
+        let (mgr, active) = TabManager::from_tabs(tabs, 0);
+        assert_eq!(active.name, "only");
+        assert_eq!(mgr.count, 1);
+        assert_eq!(mgr.active_idx, 0);
     }
 }

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -5,18 +5,43 @@ use serde::{Deserialize, Serialize};
 
 use crate::layout::Layout;
 use crate::pane::{Pane, PaneLaunch};
+use crate::project::RestartPolicy;
 use crate::render::BorderStyle;
+use crate::tab::TabManager;
 
-const SNAPSHOT_VERSION: u32 = 1;
+const SNAPSHOT_VERSION: u32 = 2;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct WorkspaceSnapshot {
     pub version: u32,
     pub shell: String,
-    pub active_pane: usize,
     pub border_style: BorderStyle,
     pub show_status_bar: bool,
+    #[serde(default = "default_true")]
+    pub show_tab_bar: bool,
+    #[serde(default = "default_scrollback")]
+    pub scrollback: usize,
+    pub active_tab: usize,
+    pub tabs: Vec<TabSnapshot>,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+fn default_scrollback() -> usize {
+    10_000
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct TabSnapshot {
+    pub name: String,
     pub layout: Layout,
+    pub active_pane: usize,
+    #[serde(default)]
+    pub zoomed_pane: Option<usize>,
+    #[serde(default)]
+    pub broadcast: bool,
     pub panes: Vec<PaneSnapshot>,
 }
 
@@ -24,80 +49,278 @@ pub struct WorkspaceSnapshot {
 pub struct PaneSnapshot {
     pub id: usize,
     pub launch: PaneLaunch,
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub cwd: Option<String>,
+    #[serde(default)]
+    pub env: HashMap<String, String>,
+    #[serde(default)]
+    pub restart: RestartPolicy,
+    #[serde(default)]
+    pub shell: Option<String>,
 }
 
 impl WorkspaceSnapshot {
+    /// Create a snapshot from live state.
+    ///
+    /// The active tab is "unpacked" (its state is in separate variables),
+    /// while inactive tabs are stored in the `TabManager`.
+    #[allow(clippy::too_many_arguments)]
     pub fn from_live(
+        tab_mgr: &TabManager,
+        tab_name: &str,
         layout: &Layout,
         panes: &HashMap<usize, Pane>,
         active_pane: usize,
+        zoomed_pane: Option<usize>,
+        broadcast: bool,
+        restart_policies: &HashMap<usize, RestartPolicy>,
         shell: &str,
         border_style: BorderStyle,
         show_status_bar: bool,
+        show_tab_bar: bool,
+        scrollback: usize,
     ) -> Self {
-        let panes = layout
-            .pane_ids()
-            .into_iter()
-            .map(|id| PaneSnapshot {
-                id,
-                launch: panes
-                    .get(&id)
-                    .map(|pane| pane.launch().clone())
-                    .unwrap_or(PaneLaunch::Shell),
-            })
-            .collect();
+        let mut tabs = Vec::with_capacity(tab_mgr.count);
+
+        for i in 0..tab_mgr.count {
+            if i == tab_mgr.active_idx {
+                // Active tab: build from unpacked state
+                tabs.push(TabSnapshot {
+                    name: tab_name.to_string(),
+                    layout: layout.clone(),
+                    active_pane,
+                    zoomed_pane,
+                    broadcast,
+                    panes: snapshot_panes(layout, panes, restart_policies),
+                });
+            } else if let Some(tab) = tab_mgr.get_inactive(i) {
+                tabs.push(TabSnapshot {
+                    name: tab.name.clone(),
+                    layout: tab.layout.clone(),
+                    active_pane: tab.active_pane,
+                    zoomed_pane: tab.zoomed_pane,
+                    broadcast: tab.broadcast,
+                    panes: snapshot_panes(&tab.layout, &tab.panes, &tab.restart_policies),
+                });
+            }
+        }
 
         Self {
             version: SNAPSHOT_VERSION,
             shell: shell.to_string(),
-            active_pane,
             border_style,
             show_status_bar,
-            layout: layout.clone(),
-            panes,
+            show_tab_bar,
+            scrollback,
+            active_tab: tab_mgr.active_idx,
+            tabs,
         }
     }
 
     pub fn validate(&self) -> anyhow::Result<()> {
-        if self.version != SNAPSHOT_VERSION {
+        if self.version != SNAPSHOT_VERSION && self.version != 1 {
             anyhow::bail!(
-                "unsupported snapshot version: {} (expected {})",
+                "unsupported snapshot version: {} (expected {} or 1)",
                 self.version,
                 SNAPSHOT_VERSION
             );
         }
 
-        let mut snapshot_ids: Vec<usize> = self.panes.iter().map(|pane| pane.id).collect();
-        snapshot_ids.sort_unstable();
-        snapshot_ids.dedup();
-
-        let mut layout_ids = self.layout.pane_ids();
-        layout_ids.sort_unstable();
-
-        if snapshot_ids != layout_ids {
-            anyhow::bail!("snapshot panes do not match layout leaves");
+        if self.tabs.is_empty() {
+            anyhow::bail!("snapshot has no tabs");
         }
 
-        if !layout_ids.contains(&self.active_pane) {
-            anyhow::bail!("snapshot active pane does not exist in layout");
+        for (ti, tab) in self.tabs.iter().enumerate() {
+            let mut snapshot_ids: Vec<usize> = tab.panes.iter().map(|pane| pane.id).collect();
+            snapshot_ids.sort_unstable();
+            snapshot_ids.dedup();
+
+            let mut layout_ids = tab.layout.pane_ids();
+            layout_ids.sort_unstable();
+
+            if snapshot_ids != layout_ids {
+                anyhow::bail!("snapshot panes do not match layout leaves in tab {}", ti);
+            }
+
+            if !layout_ids.contains(&tab.active_pane) {
+                anyhow::bail!(
+                    "snapshot active pane does not exist in layout in tab {}",
+                    ti
+                );
+            }
+        }
+
+        if self.active_tab >= self.tabs.len() {
+            anyhow::bail!("snapshot active_tab index out of range");
         }
 
         Ok(())
     }
 }
 
+/// Build PaneSnapshot vec for a set of panes.
+fn snapshot_panes(
+    layout: &Layout,
+    panes: &HashMap<usize, Pane>,
+    restart_policies: &HashMap<usize, RestartPolicy>,
+) -> Vec<PaneSnapshot> {
+    layout
+        .pane_ids()
+        .into_iter()
+        .map(|id| {
+            let pane = panes.get(&id);
+            PaneSnapshot {
+                id,
+                launch: pane
+                    .map(|p| p.launch().clone())
+                    .unwrap_or(PaneLaunch::Shell),
+                name: pane.and_then(|p| p.name().map(|s| s.to_string())),
+                cwd: pane
+                    .and_then(|p| p.live_cwd())
+                    .map(|p| p.to_string_lossy().to_string()),
+                env: pane.map(|p| p.initial_env().clone()).unwrap_or_default(),
+                restart: restart_policies.get(&id).cloned().unwrap_or_default(),
+                shell: pane.and_then(|p| p.initial_shell().map(|s| s.to_string())),
+            }
+        })
+        .collect()
+}
+
+/// Migrate a v1 snapshot to v2 format.
+fn migrate_v1(v1_json: &serde_json::Value) -> anyhow::Result<WorkspaceSnapshot> {
+    // V1 had flat fields: shell, active_pane, border_style, show_status_bar, layout, panes
+    let shell = v1_json["shell"].as_str().unwrap_or("/bin/sh").to_string();
+    let active_pane = v1_json["active_pane"].as_u64().unwrap_or(0) as usize;
+    let border_style: BorderStyle =
+        serde_json::from_value(v1_json["border_style"].clone()).unwrap_or(BorderStyle::Rounded);
+    let show_status_bar = v1_json["show_status_bar"].as_bool().unwrap_or(true);
+    let layout: Layout = serde_json::from_value(v1_json["layout"].clone())?;
+    let v1_panes: Vec<serde_json::Value> = v1_json["panes"].as_array().cloned().unwrap_or_default();
+
+    let panes: Vec<PaneSnapshot> = v1_panes
+        .into_iter()
+        .map(|p| PaneSnapshot {
+            id: p["id"].as_u64().unwrap_or(0) as usize,
+            launch: serde_json::from_value(p["launch"].clone()).unwrap_or(PaneLaunch::Shell),
+            name: None,
+            cwd: None,
+            env: HashMap::new(),
+            restart: RestartPolicy::default(),
+            shell: None,
+        })
+        .collect();
+
+    let tab = TabSnapshot {
+        name: "1".to_string(),
+        layout,
+        active_pane,
+        zoomed_pane: None,
+        broadcast: false,
+        panes,
+    };
+
+    Ok(WorkspaceSnapshot {
+        version: SNAPSHOT_VERSION,
+        shell,
+        border_style,
+        show_status_bar,
+        show_tab_bar: true,
+        scrollback: 10_000,
+        active_tab: 0,
+        tabs: vec![tab],
+    })
+}
+
 pub fn load_snapshot(path: impl AsRef<Path>) -> anyhow::Result<WorkspaceSnapshot> {
     validate_path(path.as_ref())?;
-    let snapshot = serde_json::from_str::<WorkspaceSnapshot>(&std::fs::read_to_string(path)?)?;
+    let content = std::fs::read_to_string(path)?;
+    let raw: serde_json::Value = serde_json::from_str(&content)?;
+
+    let version = raw["version"].as_u64().unwrap_or(0) as u32;
+    let snapshot = if version == 1 {
+        migrate_v1(&raw)?
+    } else {
+        serde_json::from_value::<WorkspaceSnapshot>(raw)?
+    };
+
     snapshot.validate()?;
     Ok(snapshot)
 }
 
 pub fn save_snapshot(path: impl AsRef<Path>, snapshot: &WorkspaceSnapshot) -> anyhow::Result<()> {
     validate_path(path.as_ref())?;
+    save_snapshot_raw(path, snapshot)
+}
+
+/// Save without `validate_path`. Used by auto-save where the path is managed
+/// by ezpn itself (e.g. `~/.local/share/ezpn/sessions/`).
+fn save_snapshot_raw(path: impl AsRef<Path>, snapshot: &WorkspaceSnapshot) -> anyhow::Result<()> {
     let json = serde_json::to_string_pretty(snapshot)?;
-    std::fs::write(path, json)?;
+
+    // Atomic write: write to temp file, then rename
+    let path = path.as_ref();
+    let tmp = path.with_extension(format!("tmp.{}", std::process::id()));
+    std::fs::write(&tmp, &json)?;
+    if let Err(e) = std::fs::rename(&tmp, path) {
+        // Clean up temp file on rename failure
+        let _ = std::fs::remove_file(&tmp);
+        return Err(e.into());
+    }
     Ok(())
+}
+
+/// Auto-save directory for session snapshots.
+pub fn auto_save_dir() -> Option<std::path::PathBuf> {
+    let dir = if let Ok(data_dir) = std::env::var("XDG_DATA_HOME") {
+        std::path::PathBuf::from(data_dir)
+            .join("ezpn")
+            .join("sessions")
+    } else if let Ok(home) = std::env::var("HOME") {
+        std::path::PathBuf::from(home)
+            .join(".local")
+            .join("share")
+            .join("ezpn")
+            .join("sessions")
+    } else {
+        return None;
+    };
+    std::fs::create_dir_all(&dir).ok()?;
+    Some(dir)
+}
+
+/// Auto-save a snapshot for the given session name.
+/// Uses `save_snapshot_raw` to bypass `validate_path` since the auto-save
+/// directory is managed by ezpn itself (e.g. `~/.local/share/ezpn/sessions/`).
+pub fn auto_save(session_name: &str, snapshot: &WorkspaceSnapshot) {
+    if let Some(dir) = auto_save_dir() {
+        let path = dir.join(format!("{}.json", session_name));
+        if let Err(e) = save_snapshot_raw(&path, snapshot) {
+            eprintln!("ezpn: auto-save failed: {e}");
+        }
+    }
+}
+
+/// Load an auto-saved snapshot for the given session name.
+#[allow(dead_code)] // Public API for future session resume feature
+pub fn auto_load(session_name: &str) -> Option<WorkspaceSnapshot> {
+    let dir = auto_save_dir()?;
+    let path = dir.join(format!("{}.json", session_name));
+    if !path.exists() {
+        return None;
+    }
+    // For auto-load, we skip validate_path since it's our own managed directory
+    let content = std::fs::read_to_string(&path).ok()?;
+    let raw: serde_json::Value = serde_json::from_str(&content).ok()?;
+    let version = raw["version"].as_u64().unwrap_or(0) as u32;
+    let snapshot = if version == 1 {
+        migrate_v1(&raw).ok()?
+    } else {
+        serde_json::from_value::<WorkspaceSnapshot>(raw).ok()?
+    };
+    snapshot.validate().ok()?;
+    Some(snapshot)
 }
 
 /// Reject paths that could be dangerous when invoked via IPC.
@@ -124,56 +347,68 @@ mod tests {
     use super::*;
     use crate::layout::Layout;
 
+    fn make_v2_snapshot() -> WorkspaceSnapshot {
+        WorkspaceSnapshot {
+            version: SNAPSHOT_VERSION,
+            shell: "/bin/zsh".to_string(),
+            border_style: BorderStyle::Double,
+            show_status_bar: false,
+            show_tab_bar: true,
+            scrollback: 10_000,
+            active_tab: 0,
+            tabs: vec![TabSnapshot {
+                name: "1".to_string(),
+                layout: Layout::from_grid(1, 2),
+                active_pane: 1,
+                zoomed_pane: None,
+                broadcast: false,
+                panes: vec![
+                    PaneSnapshot {
+                        id: 0,
+                        launch: PaneLaunch::Shell,
+                        name: None,
+                        cwd: None,
+                        env: HashMap::new(),
+                        restart: RestartPolicy::Never,
+                        shell: None,
+                    },
+                    PaneSnapshot {
+                        id: 1,
+                        launch: PaneLaunch::Command("cargo test".to_string()),
+                        name: Some("tests".to_string()),
+                        cwd: Some("/tmp".to_string()),
+                        env: HashMap::new(),
+                        restart: RestartPolicy::OnFailure,
+                        shell: None,
+                    },
+                ],
+            }],
+        }
+    }
+
     #[test]
     fn snapshot_validation_rejects_mismatched_panes() {
-        let snapshot = WorkspaceSnapshot {
-            version: SNAPSHOT_VERSION,
-            shell: "/bin/sh".to_string(),
-            active_pane: 0,
-            border_style: BorderStyle::Rounded,
-            show_status_bar: true,
-            layout: Layout::from_grid(1, 2),
-            panes: vec![PaneSnapshot {
-                id: 0,
-                launch: PaneLaunch::Shell,
-            }],
-        };
-
+        let mut snapshot = make_v2_snapshot();
+        snapshot.tabs[0].panes.pop(); // Remove one pane
         assert!(snapshot.validate().is_err());
     }
 
     #[test]
     fn snapshot_round_trips_json() {
-        let snapshot = WorkspaceSnapshot {
-            version: SNAPSHOT_VERSION,
-            shell: "/bin/zsh".to_string(),
-            active_pane: 1,
-            border_style: BorderStyle::Double,
-            show_status_bar: false,
-            layout: Layout::from_grid(1, 2),
-            panes: vec![
-                PaneSnapshot {
-                    id: 0,
-                    launch: PaneLaunch::Shell,
-                },
-                PaneSnapshot {
-                    id: 1,
-                    launch: PaneLaunch::Command("cargo test".to_string()),
-                },
-            ],
-        };
+        let snapshot = make_v2_snapshot();
+        let json = serde_json::to_string(&snapshot).expect("serialize snapshot");
+        let decoded =
+            serde_json::from_str::<WorkspaceSnapshot>(&json).expect("deserialize snapshot");
 
-        let decoded = serde_json::from_str::<WorkspaceSnapshot>(
-            &serde_json::to_string(&snapshot).expect("serialize snapshot"),
-        )
-        .expect("deserialize snapshot");
-
-        assert_eq!(decoded.active_pane, 1);
-        assert_eq!(decoded.panes.len(), 2);
+        assert_eq!(decoded.tabs.len(), 1);
+        assert_eq!(decoded.tabs[0].active_pane, 1);
+        assert_eq!(decoded.tabs[0].panes.len(), 2);
         assert_eq!(
-            decoded.panes[1].launch,
+            decoded.tabs[0].panes[1].launch,
             PaneLaunch::Command("cargo test".to_string())
         );
+        assert_eq!(decoded.tabs[0].panes[1].name, Some("tests".to_string()));
+        assert_eq!(decoded.tabs[0].panes[1].restart, RestartPolicy::OnFailure);
     }
 
     #[test]
@@ -182,5 +417,154 @@ mod tests {
         assert!(validate_path(Path::new(".ssh/config")).is_err());
         assert!(validate_path(Path::new(".ezpn-session.json")).is_ok());
         assert!(validate_path(Path::new("sessions/.ezpn/dev.json")).is_ok());
+    }
+
+    #[test]
+    fn v1_migration_produces_valid_v2() {
+        // Use a real Layout to get correct serialization format
+        let layout = Layout::from_grid(1, 1);
+        let layout_json = serde_json::to_value(&layout).expect("serialize layout");
+        let v1_json = serde_json::json!({
+            "version": 1,
+            "shell": "/bin/bash",
+            "active_pane": 0,
+            "border_style": "rounded",
+            "show_status_bar": true,
+            "layout": layout_json,
+            "panes": [{ "id": 0, "launch": "shell" }]
+        });
+        let snapshot = migrate_v1(&v1_json).expect("migration");
+        assert_eq!(snapshot.version, SNAPSHOT_VERSION);
+        assert_eq!(snapshot.tabs.len(), 1);
+        assert_eq!(snapshot.tabs[0].active_pane, 0);
+        assert!(snapshot.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_out_of_range_active_tab() {
+        let mut snapshot = make_v2_snapshot();
+        snapshot.active_tab = 99;
+        assert!(snapshot.validate().is_err());
+    }
+
+    #[test]
+    fn multi_tab_round_trip() {
+        let snapshot = WorkspaceSnapshot {
+            version: SNAPSHOT_VERSION,
+            shell: "/bin/zsh".to_string(),
+            border_style: BorderStyle::Rounded,
+            show_status_bar: true,
+            show_tab_bar: false,
+            scrollback: 5000,
+            active_tab: 1,
+            tabs: vec![
+                TabSnapshot {
+                    name: "editor".to_string(),
+                    layout: Layout::from_grid(1, 1),
+                    active_pane: 0,
+                    zoomed_pane: None,
+                    broadcast: false,
+                    panes: vec![PaneSnapshot {
+                        id: 0,
+                        launch: PaneLaunch::Command("nvim .".to_string()),
+                        name: Some("nvim".to_string()),
+                        cwd: Some("/home/user/project".to_string()),
+                        env: HashMap::new(),
+                        restart: RestartPolicy::Never,
+                        shell: None,
+                    }],
+                },
+                TabSnapshot {
+                    name: "server".to_string(),
+                    layout: Layout::from_grid(1, 2),
+                    active_pane: 1,
+                    zoomed_pane: Some(1),
+                    broadcast: true,
+                    panes: vec![
+                        PaneSnapshot {
+                            id: 0,
+                            launch: PaneLaunch::Command("npm run dev".to_string()),
+                            name: Some("dev".to_string()),
+                            cwd: Some("/tmp".to_string()),
+                            env: [("PORT".to_string(), "3000".to_string())].into(),
+                            restart: RestartPolicy::OnFailure,
+                            shell: Some("/bin/bash".to_string()),
+                        },
+                        PaneSnapshot {
+                            id: 1,
+                            launch: PaneLaunch::Shell,
+                            name: None,
+                            cwd: None,
+                            env: HashMap::new(),
+                            restart: RestartPolicy::Never,
+                            shell: None,
+                        },
+                    ],
+                },
+            ],
+        };
+
+        let json = serde_json::to_string_pretty(&snapshot).unwrap();
+        let decoded: WorkspaceSnapshot = serde_json::from_str(&json).unwrap();
+        decoded.validate().unwrap();
+
+        assert_eq!(decoded.active_tab, 1);
+        assert_eq!(decoded.scrollback, 5000);
+        assert!(!decoded.show_tab_bar);
+        assert_eq!(decoded.tabs.len(), 2);
+
+        // Tab 0
+        assert_eq!(decoded.tabs[0].name, "editor");
+        assert_eq!(decoded.tabs[0].panes[0].name, Some("nvim".to_string()));
+        assert_eq!(
+            decoded.tabs[0].panes[0].cwd,
+            Some("/home/user/project".to_string())
+        );
+
+        // Tab 1
+        assert_eq!(decoded.tabs[1].name, "server");
+        assert_eq!(decoded.tabs[1].zoomed_pane, Some(1));
+        assert!(decoded.tabs[1].broadcast);
+        assert_eq!(decoded.tabs[1].panes[0].restart, RestartPolicy::OnFailure);
+        assert_eq!(
+            decoded.tabs[1].panes[0].shell,
+            Some("/bin/bash".to_string())
+        );
+        assert_eq!(
+            decoded.tabs[1].panes[0].env.get("PORT"),
+            Some(&"3000".to_string())
+        );
+    }
+
+    #[test]
+    fn pane_metadata_defaults_on_missing_fields() {
+        // Simulate a v2 snapshot with minimal pane fields (serde defaults kick in)
+        let json = serde_json::json!({
+            "version": 2,
+            "shell": "/bin/sh",
+            "border_style": "single",
+            "show_status_bar": true,
+            "active_tab": 0,
+            "tabs": [{
+                "name": "1",
+                "layout": serde_json::to_value(Layout::from_grid(1, 1)).unwrap(),
+                "active_pane": 0,
+                "panes": [{
+                    "id": 0,
+                    "launch": "shell"
+                }]
+            }]
+        });
+        let snapshot: WorkspaceSnapshot = serde_json::from_value(json).unwrap();
+        snapshot.validate().unwrap();
+
+        let pane = &snapshot.tabs[0].panes[0];
+        assert_eq!(pane.name, None);
+        assert_eq!(pane.cwd, None);
+        assert!(pane.env.is_empty());
+        assert_eq!(pane.restart, RestartPolicy::Never);
+        assert_eq!(pane.shell, None);
+        assert_eq!(snapshot.scrollback, 10_000); // default_scrollback()
+        assert!(snapshot.show_tab_bar); // default_true()
     }
 }


### PR DESCRIPTION
## Summary

- **Multi-client support**: `ezpn a --shared` / `--readonly` with smallest-client sizing policy
- **Snapshot v2**: full-session save/restore — all tabs, zoom/broadcast state, pane name/cwd/env/restart/shell, auto-save on detach
- **Settings panel**: Border None option, Tab Bar / Broadcast toggles, removed redundant Pane section
- **Input latency**: poll intervals reduced from ~16ms to ~6ms worst case
- **55 tests**, `cargo clippy --all-targets -- -D warnings` clean

## Details

### Multi-Client (Phase 2)
- `AttachMode` enum: Steal (default, legacy compat), Shared, Readonly
- `C_ATTACH` protocol message with JSON `AttachRequest`
- `Vec<ConnectedClient>` replacing `Option<ClientConn>`
- Readonly clients: input filtered, excluded from detach-all
- Effective size recomputed on client add/remove with `resize_all`

### Snapshot v2 (Phase 1)
- `WorkspaceSnapshot` now wraps `Vec<TabSnapshot>` with `active_tab` index
- `PaneSnapshot` extended: `name`, `cwd`, `env`, `restart`, `shell`
- `TabSnapshot`: `zoomed_pane`, `broadcast` per tab
- v1 → v2 auto-migration in `load_snapshot()`
- Atomic write (temp + rename)
- Auto-save to `~/.local/share/ezpn/sessions/` on detach/disconnect
- `TabManager::from_tabs()` for order-preserving bulk restore
- `replace_pane()` preserves cwd/env from old pane on restart
- `scrollback` and `show_tab_bar` restored from snapshot

### Settings Panel
- Border None (key `5`) added
- Tab Bar ON/OFF toggle (wired to `settings.show_tab_bar` → render)
- Broadcast ON/OFF toggle
- Pane section (Split H/V) removed — covered by keyboard shortcuts

### Latency
- Client poll: 8ms fixed → 1ms after output, 4ms idle
- Server wake: 8ms fixed → 2ms after render, 8ms idle

## Test plan
- [x] `cargo fmt -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (55/55)
- [x] `cargo build --release`
- [ ] Manual: multi-client shared/readonly attach
- [ ] Manual: settings panel Border None / Tab Bar / Broadcast
- [ ] Manual: detach → reattach snapshot preservation
- [ ] Manual: `.ezpn.toml` with per-pane shell/cwd/env + restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)