### PR TITLE
release: v0.6.0 — Stability & Safety Net (M1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,10 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo fmt -- --check
       - run: cargo clippy --all-targets -- -D warnings
-      - run: cargo test
+      - name: Unit tests (in src/**)
+        run: cargo test --bins
+      - name: Integration tests (tests/**, --server lifecycle)
+        run: cargo test --test 'daemon_lifecycle' -- --test-threads=4
       - run: cargo build --release
 
   msrv:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,23 @@ Entries are written in **functional-only style**: every bullet describes an obse
 
 ## [Unreleased]
 
+## [0.6.0] — 2026-04-26 — Stability & Safety Net
+
 ### Added
+- **Wire-protocol versioning + handshake** (`C_HELLO` / `S_HELLO_OK` / `S_HELLO_ERR`). Mismatched majors are rejected with a clear "please upgrade" message instead of silent corruption. Backwards compatible — older clients without `C_HELLO` keep working.
+- **POSIX signal handling**: `SIGTERM` / `SIGHUP` snapshot the workspace before clean exit; `SIGCHLD` reaps zombie panes.
+- **Per-pane OSC 52 caps** (16 entries / 256 KiB total / 128 KiB single-sequence) — runaway children can no longer exhaust memory via clipboard spam.
+- **Daemon integration test harness**: spawns real `ezpn --server`, asserts handshake + ping + signal lifecycle. Wire-protocol regressions now caught in CI.
 - Repository conventions: `CONTRIBUTING.md`, `MAINTENANCE.md`, GitHub issue/PR templates, label taxonomy, `CODEOWNERS`.
+
+### Fixed
+- **Worker thread panic isolation**: PTY reader, client reader, IPC accept loop and per-client handler are now wrapped with `catch_unwind`. A bad ANSI sequence or malformed message no longer kills the daemon — only the affected pane / client is dropped.
+- Pane spawn thread panics are surfaced gracefully: partial workspace continues instead of aborting the whole session.
+- Clippy `collapsible_match` warnings (10) that broke CI on Rust 1.95.
 
 ### Changed
 - `.gitignore` hardened: secrets, AI-session files, profiling artifacts.
+- CI splits unit and integration test runs for clearer failure rows.
 
 ## [0.5.0] — 2026-04-26
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,6 +225,7 @@ dependencies = [
  "portable-pty",
  "serde",
  "serde_json",
+ "signal-hook",
  "toml",
  "unicode-width 0.2.2",
  "vt100",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,7 +164,7 @@ dependencies = [
  "crossterm_winapi",
  "mio",
  "parking_lot",
- "rustix",
+ "rustix 0.38.44",
  "serde",
  "signal-hook",
  "signal-hook-mio",
@@ -226,10 +226,17 @@ dependencies = [
  "serde",
  "serde_json",
  "signal-hook",
+ "tempfile",
  "toml",
  "unicode-width 0.2.2",
  "vt100",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "filedescriptor"
@@ -240,6 +247,25 @@ dependencies = [
  "libc",
  "thiserror",
  "winapi",
+]
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -255,9 +281,24 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -266,13 +307,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -317,6 +366,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -327,6 +382,12 @@ name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lock_api"
@@ -456,6 +517,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -472,6 +543,12 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "redox_syscall"
@@ -520,8 +597,21 @@ dependencies = [
  "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.12.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -538,6 +628,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -698,6 +794,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "termios"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -796,6 +905,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -849,6 +964,58 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.11.0",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
 
 [[package]]
 name = "winapi"
@@ -985,6 +1152,100 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.0",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ unicode-width = "0.2"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
+signal-hook = "0.3"
 
 [dev-dependencies]
 criterion = { version = "0.5", default-features = false, features = ["cargo_bench_support"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ezpn"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 rust-version = "1.82"
 autobins = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ signal-hook = "0.3"
 
 [dev-dependencies]
 criterion = { version = "0.5", default-features = false, features = ["cargo_bench_support"] }
+tempfile = "3"
 
 [[bench]]
 name = "render_hotpaths"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,9 @@
+[toolchain]
+# Pin the Rust toolchain so `cargo fmt --check` produces the same diff
+# locally and in CI. dtolnay/rust-toolchain@stable resolves this file
+# instead of grabbing whatever is freshest on the runner; without it
+# rustfmt can disagree across rustup snapshots and turn into an unfixable
+# CI loop where one side keeps re-formatting the other's output.
+channel = "1.95.0"
+components = ["clippy", "rustfmt"]
+profile = "minimal"

--- a/src/client.rs
+++ b/src/client.rs
@@ -27,6 +27,68 @@ pub enum ExitReason {
     ConnectionLost,
 }
 
+/// Send the C_HELLO handshake and read the server reply with a 500ms timeout.
+/// Returns the negotiated capability bitfield (0 if the server is too old or
+/// the handshake fails — that path keeps the connection alive so legacy attach
+/// continues to work). On `S_HELLO_ERR` the process exits with a clear message,
+/// since proceeding past a known major-version mismatch would silently corrupt
+/// the session.
+fn perform_hello(stream: &UnixStream) -> u32 {
+    let hello = protocol::HelloMessage {
+        version: protocol::PROTOCOL_VERSION,
+        capabilities: protocol::CAP_KITTY_KEYBOARD
+            | protocol::CAP_FOCUS_EVENTS
+            | protocol::CAP_TRUE_COLOR,
+        client: format!("ezpn {}", env!("CARGO_PKG_VERSION")),
+    };
+    let payload = match serde_json::to_vec(&hello) {
+        Ok(p) => p,
+        Err(_) => return 0,
+    };
+    let mut writer = stream;
+    if protocol::write_msg(&mut writer, protocol::C_HELLO, &payload).is_err() {
+        return 0;
+    }
+
+    // Brief read timeout so a pre-Hello daemon doesn't hang the client forever.
+    let mut reader = stream;
+    let prev_timeout = stream.read_timeout().ok().flatten();
+    let _ = stream.set_read_timeout(Some(Duration::from_millis(500)));
+
+    let result = protocol::read_msg(&mut reader);
+    // Restore (or clear) the prior timeout — we don't want this to leak into
+    // the steady-state read path, which expects to block indefinitely.
+    let _ = stream.set_read_timeout(prev_timeout);
+
+    match result {
+        Ok((tag, body)) if tag == protocol::S_HELLO_OK => {
+            serde_json::from_slice::<protocol::HelloOk>(&body)
+                .map(|ok| ok.capabilities)
+                .unwrap_or(0)
+        }
+        Ok((tag, body)) if tag == protocol::S_HELLO_ERR => {
+            let reason = serde_json::from_slice::<protocol::HelloErr>(&body)
+                .map(|e| {
+                    format!(
+                        "{} (server protocol version {})",
+                        e.reason, e.server_version
+                    )
+                })
+                .unwrap_or_else(|_| "unknown reason".to_string());
+            eprintln!("ezpn: server rejected handshake: {reason}");
+            std::process::exit(1);
+        }
+        _ => {
+            // Timeout, EOF, or unrelated tag — assume older daemon, fall back.
+            // Note: the unrelated-tag case is also possible if a buggy daemon
+            // sends e.g. S_OUTPUT before any client message; we discard such
+            // bytes by closing and letting the existing client_loop handshake
+            // (C_RESIZE / C_ATTACH below) drive the conversation.
+            0
+        }
+    }
+}
+
 /// Connect to a running server and act as a terminal proxy.
 /// Uses legacy C_RESIZE handshake (steal mode).
 pub fn run(socket_path: &std::path::Path, session_name: &str) -> anyhow::Result<()> {
@@ -41,6 +103,14 @@ pub fn run_with_mode(
 ) -> anyhow::Result<()> {
     let stream = UnixStream::connect(socket_path)?;
     stream.set_nonblocking(false)?;
+
+    // Capability handshake (best-effort): send C_HELLO, wait briefly for S_HELLO_OK.
+    // - On S_HELLO_OK: store negotiated caps for future feature gating.
+    // - On S_HELLO_ERR: surface the server's reason and abort cleanly.
+    // - On timeout / EOF: assume an older daemon (≤ 0.5) that doesn't speak C_HELLO,
+    //   fall through to the legacy attach path. The attach itself stays unchanged,
+    //   so this remains backwards compatible.
+    let _negotiated_caps = perform_hello(&stream);
 
     let write_stream = stream.try_clone()?;
     let read_stream = stream;

--- a/src/client.rs
+++ b/src/client.rs
@@ -51,11 +51,26 @@ pub fn run_with_mode(
     // Start reader thread: server → client
     let (server_tx, server_rx) = mpsc::channel::<(u8, Vec<u8>)>();
     std::thread::spawn(move || {
-        let mut reader = BufReader::new(read_stream);
-        while let Ok(msg) = protocol::read_msg(&mut reader) {
-            if server_tx.send(msg).is_err() {
-                break;
+        // Isolate reader panics so the client UI shuts down cleanly instead of
+        // aborting (which would leave the host terminal in raw mode).
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let mut reader = BufReader::new(read_stream);
+            while let Ok(msg) = protocol::read_msg(&mut reader) {
+                if server_tx.send(msg).is_err() {
+                    break;
+                }
             }
+        }));
+        if let Err(payload) = result {
+            let reason = match payload.downcast_ref::<&'static str>() {
+                Some(s) => (*s).to_string(),
+                None => match payload.downcast_ref::<String>() {
+                    Some(s) => s.clone(),
+                    None => "unknown panic payload".to_string(),
+                },
+            };
+            eprintln!("ezpn: client reader thread panicked: {}", reason);
+            // server_tx drops here → main loop sees Disconnected and exits cleanly.
         }
     });
 

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -120,18 +120,42 @@ pub fn start_listener() -> anyhow::Result<mpsc::Receiver<(IpcRequest, ResponseSe
     let (tx, rx) = mpsc::channel();
 
     std::thread::spawn(move || {
-        for stream in listener.incoming() {
-            match stream {
-                Ok(stream) => {
-                    let tx = tx.clone();
-                    std::thread::spawn(move || handle_client(stream, tx));
+        // Outer accept loop must survive any per-client panic; otherwise the
+        // ezpn-ctl IPC interface dies after one malformed request.
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            for stream in listener.incoming() {
+                match stream {
+                    Ok(stream) => {
+                        let tx = tx.clone();
+                        std::thread::spawn(move || {
+                            // Per-client panics never propagate.
+                            let result =
+                                std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                                    handle_client(stream, tx);
+                                }));
+                            if let Err(payload) = result {
+                                let reason = panic_payload_to_string(&payload);
+                                eprintln!("ezpn-ctl: handler thread panicked: {}", reason);
+                            }
+                        });
+                    }
+                    Err(_) => break,
                 }
-                Err(_) => break,
             }
-        }
+        }));
     });
 
     Ok(rx)
+}
+
+fn panic_payload_to_string(payload: &Box<dyn std::any::Any + Send>) -> String {
+    if let Some(s) = payload.downcast_ref::<&'static str>() {
+        return (*s).to_string();
+    }
+    if let Some(s) = payload.downcast_ref::<String>() {
+        return s.clone();
+    }
+    "unknown panic payload".to_string()
 }
 
 pub fn cleanup() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@ mod render;
 mod server;
 mod session;
 mod settings;
+mod signals;
 mod tab;
 mod workspace;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2360,7 +2360,21 @@ pub(crate) fn spawn_layout_panes(
             })
             .collect();
         for handle in handles {
-            results.push(handle.join().expect("pane spawn thread panicked"));
+            match handle.join() {
+                Ok(result) => results.push(result),
+                Err(payload) => {
+                    let reason = match payload.downcast_ref::<&'static str>() {
+                        Some(s) => (*s).to_string(),
+                        None => match payload.downcast_ref::<String>() {
+                            Some(s) => s.clone(),
+                            None => "unknown panic payload".to_string(),
+                        },
+                    };
+                    eprintln!("ezpn: pane spawn thread panicked: {}", reason);
+                    // Continue with the panes that did spawn — partial workspace
+                    // is preferable to aborting the entire session.
+                }
+            }
         }
     });
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1081,33 +1081,33 @@ fn run(stdout: &mut io::Stdout, config: &Config) -> anyhow::Result<()> {
                     // ── Resize mode: arrows resize, q/Esc exits ──
                     else if matches!(mode, InputMode::ResizeMode) {
                         match key.code {
-                            KeyCode::Left | KeyCode::Char('h') => {
-                                if layout.resize_pane(active, NavDir::Left, 0.05) {
-                                    resize_all(&mut panes, &layout, tw, th, &settings);
-                                    update.mark_all(&layout);
-                                    update.border_dirty = true;
-                                }
+                            KeyCode::Left | KeyCode::Char('h')
+                                if layout.resize_pane(active, NavDir::Left, 0.05) =>
+                            {
+                                resize_all(&mut panes, &layout, tw, th, &settings);
+                                update.mark_all(&layout);
+                                update.border_dirty = true;
                             }
-                            KeyCode::Right | KeyCode::Char('l') => {
-                                if layout.resize_pane(active, NavDir::Right, 0.05) {
-                                    resize_all(&mut panes, &layout, tw, th, &settings);
-                                    update.mark_all(&layout);
-                                    update.border_dirty = true;
-                                }
+                            KeyCode::Right | KeyCode::Char('l')
+                                if layout.resize_pane(active, NavDir::Right, 0.05) =>
+                            {
+                                resize_all(&mut panes, &layout, tw, th, &settings);
+                                update.mark_all(&layout);
+                                update.border_dirty = true;
                             }
-                            KeyCode::Up | KeyCode::Char('k') => {
-                                if layout.resize_pane(active, NavDir::Up, 0.05) {
-                                    resize_all(&mut panes, &layout, tw, th, &settings);
-                                    update.mark_all(&layout);
-                                    update.border_dirty = true;
-                                }
+                            KeyCode::Up | KeyCode::Char('k')
+                                if layout.resize_pane(active, NavDir::Up, 0.05) =>
+                            {
+                                resize_all(&mut panes, &layout, tw, th, &settings);
+                                update.mark_all(&layout);
+                                update.border_dirty = true;
                             }
-                            KeyCode::Down | KeyCode::Char('j') => {
-                                if layout.resize_pane(active, NavDir::Down, 0.05) {
-                                    resize_all(&mut panes, &layout, tw, th, &settings);
-                                    update.mark_all(&layout);
-                                    update.border_dirty = true;
-                                }
+                            KeyCode::Down | KeyCode::Char('j')
+                                if layout.resize_pane(active, NavDir::Down, 0.05) =>
+                            {
+                                resize_all(&mut panes, &layout, tw, th, &settings);
+                                update.mark_all(&layout);
+                                update.border_dirty = true;
                             }
                             KeyCode::Char('q') | KeyCode::Esc => {
                                 mode = InputMode::Normal;
@@ -1328,11 +1328,9 @@ fn run(stdout: &mut io::Stdout, config: &Config) -> anyhow::Result<()> {
                                 update.full_redraw = true;
                             }
                             // Last pane (tmux ;)
-                            KeyCode::Char(';') => {
-                                if panes.contains_key(&last_active) {
-                                    active = last_active;
-                                    update.full_redraw = true;
-                                }
+                            KeyCode::Char(';') if panes.contains_key(&last_active) => {
+                                active = last_active;
+                                update.full_redraw = true;
                             }
                             // Cycle layout (tmux Space)
                             KeyCode::Char(' ') => {

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -47,7 +47,14 @@ pub struct Pane {
     name: Option<String>,
     exit_code: Option<u32>,
     /// Pending OSC 52 clipboard sequences from child to forward to the terminal.
+    /// Capped at OSC52_MAX_ENTRIES entries / OSC52_MAX_BYTES total — drops oldest on overflow
+    /// to prevent a malicious or buggy child from exhausting memory via clipboard spam.
     pub osc52_pending: Vec<Vec<u8>>,
+    /// Running byte count of `osc52_pending` (sum of inner Vec lengths).
+    osc52_bytes: usize,
+    /// Set when `scan_osc52` had to drop a sequence due to a cap. Used by the status bar
+    /// (and tests) to signal "clipboard truncated"; reset on `take_osc52`.
+    osc52_truncated: bool,
     /// Whether the child has enabled bracketed paste mode (\x1b[?2004h).
     bracketed_paste: bool,
     /// Whether the child has requested focus events (\x1b[?1004h).
@@ -200,6 +207,8 @@ impl Pane {
             name: None,
             exit_code: None,
             osc52_pending: Vec::new(),
+            osc52_bytes: 0,
+            osc52_truncated: false,
             bracketed_paste: false,
             focus_events: false,
             initial_cwd: cwd.map(|p| p.to_path_buf()),
@@ -222,7 +231,12 @@ impl Pane {
             match self.reader_rx.try_recv() {
                 Ok(data) => {
                     // Intercept OSC 52 clipboard sequences before vt100 processing
-                    scan_osc52(&data, &mut self.osc52_pending);
+                    scan_osc52(
+                        &data,
+                        &mut self.osc52_pending,
+                        &mut self.osc52_bytes,
+                        &mut self.osc52_truncated,
+                    );
                     // Track DEC private modes from child output
                     track_dec_modes(&data, &mut self.bracketed_paste, &mut self.focus_events);
                     self.parser.process(&data);
@@ -419,7 +433,27 @@ impl Pane {
 
     /// Take pending OSC 52 clipboard sequences (clears the queue).
     pub fn take_osc52(&mut self) -> Vec<Vec<u8>> {
+        self.osc52_bytes = 0;
+        self.osc52_truncated = false;
         std::mem::take(&mut self.osc52_pending)
+    }
+
+    /// True if `scan_osc52` had to drop sequences since the last `take_osc52` call.
+    /// Surfaced for diagnostics; not currently rendered in the status bar.
+    #[allow(dead_code)]
+    pub fn osc52_was_truncated(&self) -> bool {
+        self.osc52_truncated
+    }
+
+    /// Estimated bytes the pane's vt100 ringbuffer holds. Used by the workspace-level
+    /// memory budget to pick the largest pane to warn about. The estimate is intentionally
+    /// coarse — vt100 doesn't expose precise sizing.
+    #[allow(dead_code)] // wired up by workspace budget in a follow-up; keep API stable now
+    pub fn estimated_scrollback_bytes(&self) -> usize {
+        let screen = self.parser.screen();
+        let (rows, cols) = screen.size();
+        let scrollback = screen.scrollback() + rows as usize;
+        scrollback.saturating_mul(cols as usize).saturating_mul(32)
     }
 
     /// Whether the child has bracketed paste enabled.
@@ -500,8 +534,22 @@ impl Pane {
     }
 }
 
-/// Scan raw PTY output for OSC 52 clipboard sequences and collect them.
-fn scan_osc52(data: &[u8], out: &mut Vec<Vec<u8>>) {
+/// Maximum number of pending OSC 52 sequences per pane. Beyond this, the oldest
+/// sequence is dropped (FIFO) to bound memory under hostile / buggy children.
+pub const OSC52_MAX_ENTRIES: usize = 16;
+
+/// Maximum total bytes of pending OSC 52 sequences per pane. Together with
+/// OSC52_MAX_ENTRIES this guarantees `osc52_pending` never exceeds ~256 KiB.
+pub const OSC52_MAX_BYTES: usize = 256 * 1024;
+
+/// Single-sequence cap: any individual OSC 52 longer than this is rejected
+/// outright (still increments `truncated` for diagnostics). Matches xterm's
+/// historical 100 KiB practical limit; we round up.
+pub const OSC52_MAX_SEQUENCE_BYTES: usize = 128 * 1024;
+
+/// Scan raw PTY output for OSC 52 clipboard sequences and collect them, enforcing
+/// per-pane caps so a runaway child cannot exhaust memory.
+fn scan_osc52(data: &[u8], out: &mut Vec<Vec<u8>>, out_bytes: &mut usize, truncated: &mut bool) {
     const PREFIX: &[u8] = b"\x1b]52;";
     let mut i = 0;
     while i + PREFIX.len() < data.len() {
@@ -511,11 +559,11 @@ fn scan_osc52(data: &[u8], out: &mut Vec<Vec<u8>>) {
             // Find terminator: BEL (\x07) or ST (\x1b\\)
             while i < data.len() {
                 if data[i] == 0x07 {
-                    out.push(data[start..=i].to_vec());
+                    push_osc52_capped(out, out_bytes, truncated, &data[start..=i]);
                     break;
                 }
                 if i + 1 < data.len() && data[i] == 0x1b && data[i + 1] == b'\\' {
-                    out.push(data[start..i + 2].to_vec());
+                    push_osc52_capped(out, out_bytes, truncated, &data[start..i + 2]);
                     i += 1;
                     break;
                 }
@@ -524,6 +572,30 @@ fn scan_osc52(data: &[u8], out: &mut Vec<Vec<u8>>) {
         }
         i += 1;
     }
+}
+
+fn push_osc52_capped(
+    out: &mut Vec<Vec<u8>>,
+    out_bytes: &mut usize,
+    truncated: &mut bool,
+    seq: &[u8],
+) {
+    if seq.len() > OSC52_MAX_SEQUENCE_BYTES {
+        // Single sequence too large — drop it entirely; never half-truncate (terminals
+        // treat partial OSC 52 as protocol error).
+        *truncated = true;
+        return;
+    }
+    // Drop oldest entries until both caps fit.
+    while !out.is_empty()
+        && (out.len() >= OSC52_MAX_ENTRIES || *out_bytes + seq.len() > OSC52_MAX_BYTES)
+    {
+        let dropped = out.remove(0);
+        *out_bytes -= dropped.len();
+        *truncated = true;
+    }
+    *out_bytes += seq.len();
+    out.push(seq.to_vec());
 }
 
 /// Track DEC private mode changes in raw PTY output.
@@ -722,5 +794,72 @@ fn encode_f_key_with_mods(n: u8, has_mods: bool, mods_param: u8) -> Vec<u8> {
             12 => b"\x1b[24~".to_vec(),
             _ => vec![],
         }
+    }
+}
+
+#[cfg(test)]
+#[allow(unused_imports)] // benches/render_hotpaths.rs include pane.rs via #[path];
+                        // when those build under non-test profiles the imports are
+                        // flagged though the mod itself is gated by cfg(test).
+mod osc52_tests {
+    use super::{push_osc52_capped, OSC52_MAX_BYTES, OSC52_MAX_ENTRIES, OSC52_MAX_SEQUENCE_BYTES};
+
+    fn fake_seq(payload_len: usize) -> Vec<u8> {
+        let mut v = b"\x1b]52;c;".to_vec();
+        v.extend(std::iter::repeat_n(b'A', payload_len));
+        v.push(0x07);
+        v
+    }
+
+    #[test]
+    fn entry_cap_drops_oldest() {
+        let mut out: Vec<Vec<u8>> = Vec::new();
+        let mut bytes = 0usize;
+        let mut truncated = false;
+        for _ in 0..(OSC52_MAX_ENTRIES + 4) {
+            let seq = fake_seq(8);
+            push_osc52_capped(&mut out, &mut bytes, &mut truncated, &seq);
+        }
+        assert_eq!(out.len(), OSC52_MAX_ENTRIES);
+        assert!(truncated);
+        assert!(bytes <= OSC52_MAX_BYTES);
+    }
+
+    #[test]
+    fn byte_cap_drops_oldest() {
+        let mut out: Vec<Vec<u8>> = Vec::new();
+        let mut bytes = 0usize;
+        let mut truncated = false;
+        // Each ~32 KiB; should plateau around OSC52_MAX_BYTES / 32 KiB.
+        let big = fake_seq(32 * 1024);
+        for _ in 0..16 {
+            push_osc52_capped(&mut out, &mut bytes, &mut truncated, &big);
+        }
+        assert!(bytes <= OSC52_MAX_BYTES, "bytes={bytes}");
+        assert!(truncated);
+    }
+
+    #[test]
+    fn oversize_sequence_dropped() {
+        let mut out: Vec<Vec<u8>> = Vec::new();
+        let mut bytes = 0usize;
+        let mut truncated = false;
+        let huge = fake_seq(OSC52_MAX_SEQUENCE_BYTES + 1);
+        push_osc52_capped(&mut out, &mut bytes, &mut truncated, &huge);
+        assert!(out.is_empty());
+        assert_eq!(bytes, 0);
+        assert!(truncated);
+    }
+
+    #[test]
+    fn under_caps_keeps_all() {
+        let mut out: Vec<Vec<u8>> = Vec::new();
+        let mut bytes = 0usize;
+        let mut truncated = false;
+        for _ in 0..4 {
+            push_osc52_capped(&mut out, &mut bytes, &mut truncated, &fake_seq(64));
+        }
+        assert_eq!(out.len(), 4);
+        assert!(!truncated);
     }
 }

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -445,6 +445,25 @@ impl Pane {
         self.osc52_truncated
     }
 
+    /// Reap a finished child without blocking. If the child has exited and
+    /// hadn't been observed yet, sets `alive=false` + `exit_code=Some(...)`
+    /// and returns the exit code. SIGCHLD handler in the daemon iterates
+    /// every pane and calls this so zombies don't accumulate.
+    pub fn update_alive(&mut self) -> Option<u32> {
+        if !self.alive {
+            return None;
+        }
+        match self.child.try_wait() {
+            Ok(Some(status)) => {
+                let code = status.exit_code();
+                self.exit_code = Some(code);
+                self.alive = false;
+                Some(code)
+            }
+            _ => None,
+        }
+    }
+
     /// Estimated bytes the pane's vt100 ringbuffer holds. Used by the workspace-level
     /// memory budget to pick the largest pane to warn about. The estimate is intentionally
     /// coarse — vt100 doesn't expose precise sizing.
@@ -799,8 +818,8 @@ fn encode_f_key_with_mods(n: u8, has_mods: bool, mods_param: u8) -> Vec<u8> {
 
 #[cfg(test)]
 #[allow(unused_imports)] // benches/render_hotpaths.rs include pane.rs via #[path];
-                        // when those build under non-test profiles the imports are
-                        // flagged though the mod itself is gated by cfg(test).
+                         // when those build under non-test profiles the imports are
+                         // flagged though the mod itself is gated by cfg(test).
 mod osc52_tests {
     use super::{push_osc52_capped, OSC52_MAX_BYTES, OSC52_MAX_ENTRIES, OSC52_MAX_SEQUENCE_BYTES};
 

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -153,19 +153,36 @@ impl Pane {
 
         let (tx, rx) = mpsc::sync_channel(32); // bounded: 32 * 4KB = 128KB max buffered
         std::thread::spawn(move || {
-            let mut reader = reader;
-            let mut buf = [0u8; 4096];
-            loop {
-                match reader.read(&mut buf) {
-                    Ok(0) => break,
-                    Ok(n) => {
-                        if tx.send(buf[..n].to_vec()).is_err() {
-                            break;
+            // Isolate PTY-reader panics: a bad ANSI sequence or vt100 bug must not
+            // take down the daemon. On unwind the channel drops, which causes
+            // `read_output()` to observe `TryRecvError::Disconnected` and mark the
+            // pane dead with exit_code=u32::MAX (see `read_output`).
+            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                let mut reader = reader;
+                let mut buf = [0u8; 4096];
+                loop {
+                    match reader.read(&mut buf) {
+                        Ok(0) => break,
+                        Ok(n) => {
+                            if tx.send(buf[..n].to_vec()).is_err() {
+                                break;
+                            }
+                            wake_main_loop();
                         }
-                        wake_main_loop();
+                        Err(_) => break,
                     }
-                    Err(_) => break,
                 }
+            }));
+            if let Err(payload) = result {
+                let reason = match payload.downcast_ref::<&'static str>() {
+                    Some(s) => (*s).to_string(),
+                    None => match payload.downcast_ref::<String>() {
+                        Some(s) => s.clone(),
+                        None => "unknown panic payload".to_string(),
+                    },
+                };
+                eprintln!("ezpn: PTY reader thread panicked: {}", reason);
+                wake_main_loop();
             }
         });
 
@@ -218,6 +235,13 @@ impl Pane {
                 }
                 Err(TryRecvError::Empty) => break,
                 Err(TryRecvError::Disconnected) => {
+                    // Reader thread is gone (EOF, error, or panic).
+                    // If the child is still alive, the panic-isolation path may have
+                    // killed only the reader — record sentinel exit code so callers
+                    // can detect "abnormal" pane death distinct from clean exit.
+                    if self.alive && self.exit_code.is_none() {
+                        self.exit_code = Some(u32::MAX);
+                    }
                     self.alive = false;
                     break;
                 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -18,6 +18,11 @@ pub const C_KILL: u8 = 0x04;
 pub const C_PING: u8 = 0x05;
 /// Client attach with mode. Payload = JSON `AttachRequest`.
 pub const C_ATTACH: u8 = 0x06;
+/// Client capability/version handshake. Payload = JSON `HelloMessage`.
+/// Optional but strongly recommended — without it the server assumes a
+/// "v0" capability-less client (legacy behaviour). On unknown major
+/// version, the server replies `S_HELLO_ERR` and closes.
+pub const C_HELLO: u8 = 0x07;
 
 // ── Server → Client tags ──
 
@@ -29,6 +34,31 @@ pub const S_DETACHED: u8 = 0x82;
 pub const S_EXIT: u8 = 0x83;
 /// Pong response to C_PING.
 pub const S_PONG: u8 = 0x84;
+/// Server accepts the handshake. Payload = JSON `HelloOk`.
+pub const S_HELLO_OK: u8 = 0x85;
+/// Server rejects the handshake (version mismatch, malformed payload).
+/// Payload = JSON `HelloErr`. Connection is closed after sending.
+pub const S_HELLO_ERR: u8 = 0x86;
+
+/// Wire-protocol major version. Bump on any backwards-incompatible
+/// change to message tags or framing semantics. `S_HELLO_OK` carries
+/// the server's version so the client can refuse a mismatch up-front
+/// rather than silently misparsing later messages.
+pub const PROTOCOL_VERSION: u32 = 1;
+
+/// Capability bits the daemon currently supports. Sent in `S_HELLO_OK`
+/// and intersected with the client's bits to determine what features
+/// the rest of the session may use (true-color sequences, focus events,
+/// etc.). New bits MUST keep their meaning forever — once shipped the
+/// bit number is load-bearing.
+pub const SERVER_CAPABILITIES: u32 = CAP_KITTY_KEYBOARD | CAP_FOCUS_EVENTS | CAP_TRUE_COLOR;
+
+pub const CAP_KITTY_KEYBOARD: u32 = 0x0001;
+pub const CAP_FOCUS_EVENTS: u32 = 0x0002;
+pub const CAP_TRUE_COLOR: u32 = 0x0004;
+/// Reserved for #14 (scrollback persistence). Not yet emitted by the daemon.
+#[allow(dead_code)]
+pub const CAP_SCROLLBACK_PERSIST: u32 = 0x0008;
 
 /// Maximum message payload size (16 MB).
 const MAX_PAYLOAD: usize = 16 * 1024 * 1024;
@@ -108,6 +138,38 @@ pub struct AttachRequest {
     pub mode: AttachMode,
 }
 
+/// First message a v0.6+ client sends. Everything else (C_ATTACH /
+/// C_RESIZE) follows after the server confirms with `S_HELLO_OK`.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct HelloMessage {
+    /// Major protocol version. Mismatch with `PROTOCOL_VERSION` is
+    /// fatal — the server rejects with `S_HELLO_ERR`.
+    pub version: u32,
+    /// Bitfield of `CAP_*` constants the client supports / wants enabled.
+    pub capabilities: u32,
+    /// Free-form client identifier ("ezpn 0.6.0", "ezpn-ctl 0.6.0"…).
+    /// Used for logging only — never load-bearing.
+    pub client: String,
+}
+
+/// Response payload for `S_HELLO_OK`.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct HelloOk {
+    pub version: u32,
+    /// Intersection of client + server caps. Both sides agree to use
+    /// only these features for the rest of the session.
+    pub capabilities: u32,
+    pub server: String,
+}
+
+/// Response payload for `S_HELLO_ERR` — connection is closed after this.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct HelloErr {
+    pub reason: String,
+    /// Server's preferred version, so the client can hint at the upgrade.
+    pub server_version: u32,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -146,5 +208,69 @@ mod tests {
         let (tag, payload) = read_msg(&mut buf.as_slice()).unwrap();
         assert_eq!(tag, C_EVENT);
         assert_eq!(payload, b"hello");
+    }
+
+    #[test]
+    fn hello_message_round_trip() {
+        let hello = HelloMessage {
+            version: PROTOCOL_VERSION,
+            capabilities: CAP_KITTY_KEYBOARD | CAP_TRUE_COLOR,
+            client: "ezpn-test".to_string(),
+        };
+        let json = serde_json::to_vec(&hello).unwrap();
+        let decoded: HelloMessage = serde_json::from_slice(&json).unwrap();
+        assert_eq!(decoded.version, PROTOCOL_VERSION);
+        assert_eq!(
+            decoded.capabilities & CAP_KITTY_KEYBOARD,
+            CAP_KITTY_KEYBOARD
+        );
+        assert_eq!(decoded.client, "ezpn-test");
+    }
+
+    #[test]
+    fn hello_ok_carries_intersection() {
+        let server_caps = SERVER_CAPABILITIES;
+        let client_caps = CAP_KITTY_KEYBOARD | CAP_SCROLLBACK_PERSIST; // unknown bit set
+        let agreed = server_caps & client_caps;
+        // We agree on what BOTH sides know. Client requesting a future bit
+        // (SCROLLBACK_PERSIST) must not magically enable it server-side.
+        assert_eq!(agreed, CAP_KITTY_KEYBOARD);
+    }
+
+    #[test]
+    fn hello_err_includes_server_version() {
+        let err = HelloErr {
+            reason: "client/server major mismatch".to_string(),
+            server_version: PROTOCOL_VERSION,
+        };
+        let json = serde_json::to_vec(&err).unwrap();
+        let decoded: HelloErr = serde_json::from_slice(&json).unwrap();
+        assert_eq!(decoded.server_version, PROTOCOL_VERSION);
+        assert!(decoded.reason.contains("mismatch"));
+    }
+
+    #[test]
+    fn hello_tags_distinct_from_existing() {
+        // Defensive: catch accidental tag collisions when constants are added.
+        let tags = [
+            C_EVENT, C_DETACH, C_RESIZE, C_KILL, C_PING, C_ATTACH, C_HELLO,
+        ];
+        let mut sorted = tags.to_vec();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(sorted.len(), tags.len(), "client tag collision");
+
+        let stags = [
+            S_OUTPUT,
+            S_DETACHED,
+            S_EXIT,
+            S_PONG,
+            S_HELLO_OK,
+            S_HELLO_ERR,
+        ];
+        let mut sorted_s = stags.to_vec();
+        sorted_s.sort_unstable();
+        sorted_s.dedup();
+        assert_eq!(sorted_s.len(), stags.len(), "server tag collision");
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1690,33 +1690,31 @@ fn process_key(
     // ── Resize mode ──
     if matches!(mode, InputMode::ResizeMode) {
         match key.code {
-            KeyCode::Left | KeyCode::Char('h') => {
-                if layout.resize_pane(*active, NavDir::Left, 0.05) {
-                    super::resize_all(panes, layout, tw, th, settings);
-                    update.mark_all(layout);
-                    update.border_dirty = true;
-                }
+            KeyCode::Left | KeyCode::Char('h')
+                if layout.resize_pane(*active, NavDir::Left, 0.05) =>
+            {
+                super::resize_all(panes, layout, tw, th, settings);
+                update.mark_all(layout);
+                update.border_dirty = true;
             }
-            KeyCode::Right | KeyCode::Char('l') => {
-                if layout.resize_pane(*active, NavDir::Right, 0.05) {
-                    super::resize_all(panes, layout, tw, th, settings);
-                    update.mark_all(layout);
-                    update.border_dirty = true;
-                }
+            KeyCode::Right | KeyCode::Char('l')
+                if layout.resize_pane(*active, NavDir::Right, 0.05) =>
+            {
+                super::resize_all(panes, layout, tw, th, settings);
+                update.mark_all(layout);
+                update.border_dirty = true;
             }
-            KeyCode::Up | KeyCode::Char('k') => {
-                if layout.resize_pane(*active, NavDir::Up, 0.05) {
-                    super::resize_all(panes, layout, tw, th, settings);
-                    update.mark_all(layout);
-                    update.border_dirty = true;
-                }
+            KeyCode::Up | KeyCode::Char('k') if layout.resize_pane(*active, NavDir::Up, 0.05) => {
+                super::resize_all(panes, layout, tw, th, settings);
+                update.mark_all(layout);
+                update.border_dirty = true;
             }
-            KeyCode::Down | KeyCode::Char('j') => {
-                if layout.resize_pane(*active, NavDir::Down, 0.05) {
-                    super::resize_all(panes, layout, tw, th, settings);
-                    update.mark_all(layout);
-                    update.border_dirty = true;
-                }
+            KeyCode::Down | KeyCode::Char('j')
+                if layout.resize_pane(*active, NavDir::Down, 0.05) =>
+            {
+                super::resize_all(panes, layout, tw, th, settings);
+                update.mark_all(layout);
+                update.border_dirty = true;
             }
             KeyCode::Char('q') | KeyCode::Esc => {
                 *mode = InputMode::Normal;
@@ -1935,11 +1933,9 @@ fn process_key(
                 update.full_redraw = true;
             }
             // Last pane
-            KeyCode::Char(';') => {
-                if panes.contains_key(last_active) {
-                    *active = *last_active;
-                    update.full_redraw = true;
-                }
+            KeyCode::Char(';') if panes.contains_key(last_active) => {
+                *active = *last_active;
+                update.full_redraw = true;
             }
             // Equalize (space)
             KeyCode::Char(' ') => {

--- a/src/server.rs
+++ b/src/server.rs
@@ -129,6 +129,9 @@ enum ClientMsg {
     Disconnected,
     /// Kill the server (from `ezpn kill`).
     Kill,
+    /// Reader thread panicked. Server treats this like Disconnected
+    /// after logging the payload to stderr.
+    Panicked(String),
 }
 
 /// Connected client with attach mode and per-client state.
@@ -626,6 +629,14 @@ pub fn run(session_name: &str, args: &[String]) -> anyhow::Result<()> {
                         break;
                     }
                     Ok(ClientMsg::Disconnected) => {
+                        disconnect_ids.push(client_id);
+                        break;
+                    }
+                    Ok(ClientMsg::Panicked(reason)) => {
+                        eprintln!(
+                            "ezpn: client reader thread panicked (id={}): {}",
+                            client_id, reason
+                        );
                         disconnect_ids.push(client_id);
                         break;
                     }
@@ -1157,6 +1168,17 @@ pub fn run(session_name: &str, args: &[String]) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Convert a `catch_unwind` payload into a printable reason string.
+fn panic_payload_to_string(payload: &Box<dyn std::any::Any + Send>) -> String {
+    if let Some(s) = payload.downcast_ref::<&'static str>() {
+        return (*s).to_string();
+    }
+    if let Some(s) = payload.downcast_ref::<String>() {
+        return s.clone();
+    }
+    "unknown panic payload".to_string()
+}
+
 /// Reader thread for client socket messages.
 fn client_reader(stream: UnixStream, tx: mpsc::Sender<ClientMsg>) {
     let mut reader = BufReader::new(stream);
@@ -1218,8 +1240,17 @@ fn accept_client(
     if let Ok(read_conn) = conn.try_clone() {
         conn.set_read_timeout(None).ok();
         let (msg_tx, msg_rx) = mpsc::channel();
+        let panic_tx = msg_tx.clone();
         std::thread::spawn(move || {
-            client_reader(read_conn, msg_tx);
+            // Isolate reader-thread panics so one bad client cannot kill the daemon.
+            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                client_reader(read_conn, msg_tx);
+            }));
+            if let Err(payload) = result {
+                let reason = panic_payload_to_string(&payload);
+                let _ = panic_tx.send(ClientMsg::Panicked(reason));
+                crate::pane::wake_main_loop();
+            }
         });
         let client_id = NEXT_CLIENT_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         clients.push(ConnectedClient {

--- a/src/server.rs
+++ b/src/server.rs
@@ -140,6 +140,11 @@ struct ConnectedClient {
     writer: std::io::BufWriter<UnixStream>,
     event_rx: mpsc::Receiver<ClientMsg>,
     mode: protocol::AttachMode,
+    /// Capability bits negotiated during the C_HELLO handshake. Zero for
+    /// legacy clients that connected without a Hello — those are treated
+    /// as having no extended capabilities.
+    #[allow(dead_code)]
+    caps: u32,
     tw: u16,
     th: u16,
 }
@@ -508,7 +513,50 @@ pub fn run(session_name: &str, args: &[String]) -> anyhow::Result<()> {
             {
                 drop(conn);
             } else {
-                match protocol::read_msg(&mut &conn) {
+                // The first message may be C_HELLO; if so, negotiate and read again.
+                // This is the only place version negotiation happens — once accepted,
+                // the rest of the connection uses tags as defined in protocol.rs.
+                let mut negotiated_caps: u32 = 0;
+                let mut first_msg = protocol::read_msg(&mut &conn);
+                if let Ok((protocol::C_HELLO, ref payload)) = first_msg {
+                    match serde_json::from_slice::<protocol::HelloMessage>(payload) {
+                        Ok(hello) if hello.version == protocol::PROTOCOL_VERSION => {
+                            negotiated_caps = hello.capabilities & protocol::SERVER_CAPABILITIES;
+                            let ok = protocol::HelloOk {
+                                version: protocol::PROTOCOL_VERSION,
+                                capabilities: negotiated_caps,
+                                server: format!("ezpn {}", env!("CARGO_PKG_VERSION")),
+                            };
+                            let mut w = &conn;
+                            let _ = protocol::write_msg(
+                                &mut w,
+                                protocol::S_HELLO_OK,
+                                &serde_json::to_vec(&ok).unwrap_or_default(),
+                            );
+                            // Read the real first message (attach / ping / kill / …)
+                            first_msg = protocol::read_msg(&mut &conn);
+                        }
+                        _ => {
+                            // Mismatched major or malformed payload → reject + close.
+                            let err = protocol::HelloErr {
+                                reason:
+                                    "client/server protocol version mismatch — please upgrade ezpn"
+                                        .to_string(),
+                                server_version: protocol::PROTOCOL_VERSION,
+                            };
+                            let mut w = &conn;
+                            let _ = protocol::write_msg(
+                                &mut w,
+                                protocol::S_HELLO_ERR,
+                                &serde_json::to_vec(&err).unwrap_or_default(),
+                            );
+                            drop(conn);
+                            continue;
+                        }
+                    }
+                }
+
+                match first_msg {
                     Ok((protocol::C_PING, _)) => {
                         // Liveness probe — respond and close, no side effects
                         let mut w = &conn;
@@ -535,6 +583,7 @@ pub fn run(session_name: &str, args: &[String]) -> anyhow::Result<()> {
                                 req.cols,
                                 req.rows,
                                 req.mode,
+                                negotiated_caps,
                                 &mut clients,
                                 &mut panes,
                                 &layout,
@@ -555,6 +604,7 @@ pub fn run(session_name: &str, args: &[String]) -> anyhow::Result<()> {
                                 w,
                                 h,
                                 protocol::AttachMode::Steal,
+                                negotiated_caps,
                                 &mut clients,
                                 &mut panes,
                                 &layout,
@@ -1218,6 +1268,7 @@ fn accept_client(
     new_w: u16,
     new_h: u16,
     mode: protocol::AttachMode,
+    caps: u32,
     clients: &mut Vec<ConnectedClient>,
     panes: &mut HashMap<usize, Pane>,
     layout: &Layout,
@@ -1258,6 +1309,7 @@ fn accept_client(
             writer: std::io::BufWriter::new(conn),
             event_rx: msg_rx,
             mode,
+            caps,
             tw: new_w,
             th: new_h,
         });

--- a/src/server.rs
+++ b/src/server.rs
@@ -24,6 +24,7 @@ use crate::protocol;
 use crate::render::{self, BorderCache};
 use crate::session;
 use crate::settings::{Settings, SettingsAction};
+use crate::signals::{Signal as Sig, SignalHandlers};
 use crate::workspace::{self, WorkspaceSnapshot};
 
 /// Input state machine for prefix key support.
@@ -196,6 +197,17 @@ pub fn run(session_name: &str, args: &[String]) -> anyhow::Result<()> {
     settings.show_status_bar = file_config.show_status_bar;
     settings.show_tab_bar = file_config.show_tab_bar;
     let prefix_key = file_config.prefix_key;
+
+    // Install POSIX signal handlers (issue #11). Failure to install is logged
+    // but non-fatal — the daemon still runs, just without graceful shutdown
+    // and zombie reaping. We never want a syscall failure to block startup.
+    let mut sig_handlers = match SignalHandlers::install() {
+        Ok(h) => Some(h),
+        Err(e) => {
+            eprintln!("ezpn: signal handlers unavailable, running without them: {e}");
+            None
+        }
+    };
 
     // Auto-restart state
     let mut restart_policies: HashMap<usize, project::RestartPolicy> = HashMap::new();
@@ -1193,6 +1205,57 @@ pub fn run(session_name: &str, args: &[String]) -> anyhow::Result<()> {
                             true
                         }
                     });
+                }
+            }
+        }
+
+        // ── POSIX signal handling (issue #11) ──
+        if let Some(sh) = sig_handlers.as_mut() {
+            for sig in sh.drain() {
+                match sig {
+                    Sig::Child => {
+                        // Reap any pane whose child exited externally (e.g. user
+                        // killed it from another terminal). update_alive() is a
+                        // no-op for already-dead panes, so iterating all is cheap.
+                        let mut any_changed = false;
+                        for pane in panes.values_mut() {
+                            if pane.update_alive().is_some() {
+                                any_changed = true;
+                            }
+                        }
+                        if any_changed {
+                            update.full_redraw = true;
+                        }
+                    }
+                    Sig::Terminate => {
+                        // Graceful shutdown: persist the live workspace snapshot
+                        // before tearing down so reattach restores layout/commands.
+                        let snapshot = WorkspaceSnapshot::from_live(
+                            &tab_mgr,
+                            &tab_name,
+                            &layout,
+                            &panes,
+                            active,
+                            zoomed_pane,
+                            broadcast,
+                            &restart_policies,
+                            &default_shell,
+                            settings.border_style,
+                            settings.show_status_bar,
+                            settings.show_tab_bar,
+                            effective_scrollback,
+                        );
+                        workspace::auto_save(session_name, &snapshot);
+                        for pane in panes.values_mut() {
+                            pane.kill();
+                        }
+                        for c in &mut clients {
+                            let _ = protocol::write_msg(&mut c.writer, protocol::S_EXIT, &[]);
+                        }
+                        session::cleanup(session_name);
+                        ipc::cleanup();
+                        return Ok(());
+                    }
                 }
             }
         }

--- a/src/signals.rs
+++ b/src/signals.rs
@@ -1,0 +1,81 @@
+//! POSIX signal handling for the daemon.
+//!
+//! `signal-hook` registers the actual handlers (using a self-pipe internally)
+//! so the only async-signal-safe work happens off-thread. The daemon's main
+//! loop drains [`SignalHandlers::drain`] every tick and handles each fired
+//! signal synchronously, where it's safe to call into the workspace, render
+//! state, etc.
+//!
+//! Signals handled:
+//! - `SIGTERM`, `SIGHUP` → graceful shutdown (auto-save snapshot, cleanup
+//!   socket, exit cleanly). Replaces the previous behaviour of dying via
+//!   default disposition (no snapshot, dangling socket).
+//! - `SIGCHLD` → reap exited children. Without this, finished panes become
+//!   zombies until the daemon also exits (memory + slot leak in long-lived
+//!   sessions with many spawn/exit cycles).
+
+#[cfg(unix)]
+use signal_hook::consts::signal as sig;
+#[cfg(unix)]
+use signal_hook::iterator::Signals;
+
+/// One firing of a registered signal. The set is intentionally small —
+/// extending it requires updating both [`SignalHandlers::install`] and the
+/// dispatch site in `server::run`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Signal {
+    /// SIGTERM or SIGHUP — caller should snapshot + cleanup + exit.
+    Terminate,
+    /// SIGCHLD — caller should iterate panes and reap zombies.
+    Child,
+}
+
+#[cfg(unix)]
+pub struct SignalHandlers {
+    inner: Signals,
+}
+
+#[cfg(unix)]
+impl SignalHandlers {
+    /// Register handlers for SIGTERM, SIGHUP, SIGCHLD. Idempotent at the
+    /// process level — the underlying `Signals` can be constructed multiple
+    /// times in tests, but production code should call this exactly once.
+    pub fn install() -> std::io::Result<Self> {
+        let inner = Signals::new([sig::SIGTERM, sig::SIGHUP, sig::SIGCHLD])?;
+        Ok(Self { inner })
+    }
+
+    /// Non-blocking drain — returns every signal that fired since the last
+    /// call. Empty Vec if nothing fired (typical case in the hot loop).
+    pub fn drain(&mut self) -> Vec<Signal> {
+        let mut out = Vec::new();
+        for s in self.inner.pending() {
+            // Match by const value rather than pattern — uppercase
+            // constants pulled in via `use sig` would otherwise be parsed
+            // as variable bindings inside a `match` arm.
+            if s == sig::SIGTERM || s == sig::SIGHUP {
+                out.push(Signal::Terminate);
+            } else if s == sig::SIGCHLD {
+                out.push(Signal::Child);
+            }
+            // anything else: we never registered for it
+        }
+        out
+    }
+}
+
+// Non-unix stub so the rest of the crate keeps compiling on non-POSIX
+// platforms. ezpn currently only ships for macOS / Linux, but the file's
+// callers are platform-neutral.
+#[cfg(not(unix))]
+pub struct SignalHandlers;
+
+#[cfg(not(unix))]
+impl SignalHandlers {
+    pub fn install() -> std::io::Result<Self> {
+        Ok(Self)
+    }
+    pub fn drain(&mut self) -> Vec<Signal> {
+        Vec::new()
+    }
+}

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -55,7 +55,7 @@ pub fn spawn_test_daemon(prefix: &str) -> DaemonHandle {
     // `ezpn --server <name>` is the daemon entrypoint used internally by
     // `session::spawn_server`. It binds the per-session socket and runs the
     // event loop without ever needing a TTY (so it's safe for CI).
-    let child = Command::new(ezpn_bin())
+    let mut child = Command::new(ezpn_bin())
         .args(["--server", &session])
         .env("XDG_RUNTIME_DIR", &runtime)
         .stdin(Stdio::null())
@@ -78,6 +78,11 @@ pub fn spawn_test_daemon(prefix: &str) -> DaemonHandle {
         }
         std::thread::sleep(Duration::from_millis(20));
     }
+    // Daemon never bound — make sure the child gets reaped before we panic
+    // so clippy's "spawned process must be wait()ed" lint stays satisfied
+    // and we don't leak a process via an aborted test.
+    let _ = child.kill();
+    let _ = child.wait();
     panic!("daemon socket {} never appeared within 3s", sock.display());
 }
 
@@ -175,15 +180,14 @@ pub fn connect_and_hello(sock: &Path) -> (UnixStream, u32) {
         .set_read_timeout(Some(Duration::from_secs(2)))
         .expect("set timeout");
 
-    let hello = format!(
-        r#"{{"version":1,"capabilities":7,"client":"integration-test"}}"#,
-    );
+    let hello = r#"{"version":1,"capabilities":7,"client":"integration-test"}"#;
     write_msg(&mut stream, C_HELLO, hello.as_bytes()).expect("send C_HELLO");
 
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
     let (tag, body) = read_msg(&mut reader).expect("read hello reply");
     assert_eq!(
-        tag, S_HELLO_OK,
+        tag,
+        S_HELLO_OK,
         "expected S_HELLO_OK, got 0x{tag:02x} body={}",
         String::from_utf8_lossy(&body)
     );

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,0 +1,206 @@
+//! Shared helpers for ezpn integration tests.
+//!
+//! These tests spawn the real `ezpn` binary with a unique per-test session
+//! name + temp `XDG_RUNTIME_DIR` so they can run in parallel on shared CI
+//! without clobbering each other's sockets. They speak the wire protocol
+//! directly (no terminal emulation) — that's why no `expectrl` dependency.
+//!
+//! The harness is intentionally small: enough to assert daemon lifecycle
+//! (spawn → live → graceful shutdown) and reader-thread isolation. Richer
+//! interactive scenarios are M2 follow-ups.
+
+#![allow(dead_code)]
+
+use std::io::{BufReader, Read, Write};
+use std::os::unix::net::UnixStream;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+static SESSION_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// Build a unique session name per call. Combines the test name, the test
+/// process PID, and an atomic counter so concurrent `cargo test` jobs never
+/// collide on socket paths.
+pub fn unique_session_name(prefix: &str) -> String {
+    let n = SESSION_COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("{prefix}-{}-{n}", std::process::id())
+}
+
+/// Path to the just-built `ezpn` binary. Cargo sets `CARGO_BIN_EXE_<name>`
+/// for integration tests pointing at the freshly compiled artifact, which
+/// is what we want — never a stale `~/.cargo/bin/ezpn`.
+pub fn ezpn_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_ezpn"))
+}
+
+/// Compute the per-session socket path the daemon will bind. Mirrors
+/// `session::socket_path` so test code stays decoupled from daemon
+/// internals — if the production scheme changes, the test fails noisily
+/// rather than silently looking in the wrong place.
+pub fn socket_path(runtime_dir: &Path, session_name: &str) -> PathBuf {
+    runtime_dir.join(format!("ezpn-session-{session_name}.sock"))
+}
+
+/// Spawn the daemon in detached mode (`ezpn -d -S <name>`) under an
+/// isolated `XDG_RUNTIME_DIR` and wait up to 3s for the socket to appear.
+/// Returns a `DaemonHandle` that kills + cleans up on drop, so a panic in
+/// the test body never leaves a zombie behind.
+pub fn spawn_test_daemon(prefix: &str) -> DaemonHandle {
+    let session = unique_session_name(prefix);
+    let dir = tempfile::tempdir().expect("tempdir");
+    let runtime = dir.path().to_path_buf();
+
+    // `ezpn --server <name>` is the daemon entrypoint used internally by
+    // `session::spawn_server`. It binds the per-session socket and runs the
+    // event loop without ever needing a TTY (so it's safe for CI).
+    let child = Command::new(ezpn_bin())
+        .args(["--server", &session])
+        .env("XDG_RUNTIME_DIR", &runtime)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn ezpn --server");
+
+    let sock = socket_path(&runtime, &session);
+    let deadline = Instant::now() + Duration::from_secs(3);
+    while Instant::now() < deadline {
+        if sock.exists() {
+            return DaemonHandle {
+                child,
+                _runtime_dir: dir,
+                runtime,
+                session,
+                sock,
+            };
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    panic!("daemon socket {} never appeared within 3s", sock.display());
+}
+
+/// Owns a running daemon for the lifetime of a test. Drop handler kills
+/// the process so failed tests can't leave background daemons running.
+pub struct DaemonHandle {
+    child: Child,
+    _runtime_dir: tempfile::TempDir, // RAII — deletes the dir on drop
+    pub runtime: PathBuf,
+    pub session: String,
+    pub sock: PathBuf,
+}
+
+impl DaemonHandle {
+    pub fn pid(&self) -> u32 {
+        self.child.id()
+    }
+
+    /// Send SIGTERM and wait up to `timeout` for the process to exit.
+    /// Returns true on clean exit, false on timeout (test should fail).
+    pub fn shutdown_with_sigterm(&mut self, timeout: Duration) -> bool {
+        unsafe {
+            libc::kill(self.child.id() as libc::pid_t, libc::SIGTERM);
+        }
+        let deadline = Instant::now() + timeout;
+        while Instant::now() < deadline {
+            if let Ok(Some(_)) = self.child.try_wait() {
+                return true;
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        false
+    }
+}
+
+impl Drop for DaemonHandle {
+    fn drop(&mut self) {
+        // Best-effort: SIGTERM, brief grace, then SIGKILL if still alive.
+        unsafe {
+            libc::kill(self.child.id() as libc::pid_t, libc::SIGTERM);
+        }
+        let deadline = Instant::now() + Duration::from_millis(500);
+        while Instant::now() < deadline {
+            if let Ok(Some(_)) = self.child.try_wait() {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+// ── Minimal protocol helpers (subset that doesn't depend on `crate::protocol`) ──
+// We keep these self-contained rather than importing crate internals so the
+// integration tests catch wire-format regressions even if the internal API drifts.
+
+pub const C_HELLO: u8 = 0x07;
+pub const C_PING: u8 = 0x05;
+pub const C_DETACH: u8 = 0x02;
+pub const S_HELLO_OK: u8 = 0x85;
+pub const S_HELLO_ERR: u8 = 0x86;
+pub const S_PONG: u8 = 0x84;
+
+pub fn write_msg(stream: &mut impl Write, tag: u8, payload: &[u8]) -> std::io::Result<()> {
+    let len = (payload.len() as u32).to_be_bytes();
+    stream.write_all(&[tag])?;
+    stream.write_all(&len)?;
+    if !payload.is_empty() {
+        stream.write_all(payload)?;
+    }
+    stream.flush()
+}
+
+pub fn read_msg(stream: &mut impl Read) -> std::io::Result<(u8, Vec<u8>)> {
+    let mut tag = [0u8; 1];
+    stream.read_exact(&mut tag)?;
+    let mut len_buf = [0u8; 4];
+    stream.read_exact(&mut len_buf)?;
+    let len = u32::from_be_bytes(len_buf) as usize;
+    let mut payload = vec![0u8; len];
+    if len > 0 {
+        stream.read_exact(&mut payload)?;
+    }
+    Ok((tag[0], payload))
+}
+
+/// Connect to the daemon and complete the v1 Hello handshake. Returns the
+/// negotiated capability bitfield from `S_HELLO_OK` so the caller can assert
+/// on it. Panics with a descriptive message if anything fails — this is for
+/// tests, not production code.
+pub fn connect_and_hello(sock: &Path) -> (UnixStream, u32) {
+    let mut stream = UnixStream::connect(sock).expect("connect to daemon socket");
+    stream
+        .set_read_timeout(Some(Duration::from_secs(2)))
+        .expect("set timeout");
+
+    let hello = format!(
+        r#"{{"version":1,"capabilities":7,"client":"integration-test"}}"#,
+    );
+    write_msg(&mut stream, C_HELLO, hello.as_bytes()).expect("send C_HELLO");
+
+    let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
+    let (tag, body) = read_msg(&mut reader).expect("read hello reply");
+    assert_eq!(
+        tag, S_HELLO_OK,
+        "expected S_HELLO_OK, got 0x{tag:02x} body={}",
+        String::from_utf8_lossy(&body)
+    );
+    // Parse `"capabilities":N` out of the JSON without pulling serde into
+    // the test crate. We control both ends, so a regex-free byte search is
+    // fine; if it ever breaks the assertion message will say so loudly.
+    let body_str = String::from_utf8_lossy(&body);
+    let caps = parse_caps(&body_str).unwrap_or(0);
+    (stream, caps)
+}
+
+fn parse_caps(json: &str) -> Option<u32> {
+    let needle = "\"capabilities\":";
+    let i = json.find(needle)? + needle.len();
+    let tail = &json[i..];
+    let end = tail
+        .find(|c: char| !c.is_ascii_digit())
+        .unwrap_or(tail.len());
+    tail[..end].parse().ok()
+}

--- a/tests/daemon_lifecycle.rs
+++ b/tests/daemon_lifecycle.rs
@@ -31,14 +31,16 @@ fn hello_handshake_succeeds_for_v1() {
     let (_stream, caps) = connect_and_hello(&daemon.sock);
     // Server caps include kitty kbd + focus events + true color = 0x07.
     // Client requested 0x07 too, so intersection should be 0x07.
-    assert_eq!(caps, 0x07, "negotiated caps should be 0x07, got 0x{caps:02x}");
+    assert_eq!(
+        caps, 0x07,
+        "negotiated caps should be 0x07, got 0x{caps:02x}"
+    );
 }
 
 #[test]
 fn hello_handshake_rejects_wrong_major() {
     let daemon = spawn_test_daemon("hello-bad-version");
-    let mut stream =
-        std::os::unix::net::UnixStream::connect(&daemon.sock).expect("connect");
+    let mut stream = std::os::unix::net::UnixStream::connect(&daemon.sock).expect("connect");
     stream
         .set_read_timeout(Some(Duration::from_secs(2)))
         .unwrap();
@@ -62,8 +64,7 @@ fn sigterm_triggers_graceful_shutdown() {
     let mut daemon = spawn_test_daemon("sigterm");
     // Confirm daemon is alive via ping first
     {
-        let mut stream =
-            std::os::unix::net::UnixStream::connect(&daemon.sock).expect("connect");
+        let mut stream = std::os::unix::net::UnixStream::connect(&daemon.sock).expect("connect");
         stream
             .set_read_timeout(Some(Duration::from_secs(2)))
             .unwrap();

--- a/tests/daemon_lifecycle.rs
+++ b/tests/daemon_lifecycle.rs
@@ -1,0 +1,82 @@
+//! End-to-end daemon lifecycle tests covering the M1 stability work:
+//! - C_HELLO version negotiation (#10)
+//! - Graceful shutdown via SIGTERM with snapshot save (#11)
+//! - Liveness probe (`C_PING` / `S_PONG`)
+//!
+//! These tests spawn the real `ezpn` binary; they exercise the wire
+//! protocol over a real Unix socket, not a mock. That's the only way
+//! to catch protocol regressions.
+
+mod common;
+
+use common::*;
+use std::time::Duration;
+
+#[test]
+fn daemon_responds_to_ping() {
+    let daemon = spawn_test_daemon("ping");
+    let mut stream =
+        std::os::unix::net::UnixStream::connect(&daemon.sock).expect("connect for ping");
+    stream
+        .set_read_timeout(Some(Duration::from_secs(2)))
+        .unwrap();
+    write_msg(&mut stream, C_PING, &[]).expect("send C_PING");
+    let (tag, _) = read_msg(&mut stream).expect("read pong");
+    assert_eq!(tag, S_PONG, "expected S_PONG, got 0x{tag:02x}");
+}
+
+#[test]
+fn hello_handshake_succeeds_for_v1() {
+    let daemon = spawn_test_daemon("hello-ok");
+    let (_stream, caps) = connect_and_hello(&daemon.sock);
+    // Server caps include kitty kbd + focus events + true color = 0x07.
+    // Client requested 0x07 too, so intersection should be 0x07.
+    assert_eq!(caps, 0x07, "negotiated caps should be 0x07, got 0x{caps:02x}");
+}
+
+#[test]
+fn hello_handshake_rejects_wrong_major() {
+    let daemon = spawn_test_daemon("hello-bad-version");
+    let mut stream =
+        std::os::unix::net::UnixStream::connect(&daemon.sock).expect("connect");
+    stream
+        .set_read_timeout(Some(Duration::from_secs(2)))
+        .unwrap();
+    // version=999 is unknown to the server → expect S_HELLO_ERR
+    let bad_hello = r#"{"version":999,"capabilities":0,"client":"future-test"}"#;
+    write_msg(&mut stream, C_HELLO, bad_hello.as_bytes()).expect("send bad hello");
+    let (tag, body) = read_msg(&mut stream).expect("read reply");
+    assert_eq!(
+        tag, S_HELLO_ERR,
+        "expected S_HELLO_ERR for major mismatch, got 0x{tag:02x}"
+    );
+    let s = String::from_utf8_lossy(&body);
+    assert!(
+        s.contains("mismatch") || s.contains("upgrade"),
+        "error reason should mention mismatch/upgrade, got: {s}"
+    );
+}
+
+#[test]
+fn sigterm_triggers_graceful_shutdown() {
+    let mut daemon = spawn_test_daemon("sigterm");
+    // Confirm daemon is alive via ping first
+    {
+        let mut stream =
+            std::os::unix::net::UnixStream::connect(&daemon.sock).expect("connect");
+        stream
+            .set_read_timeout(Some(Duration::from_secs(2)))
+            .unwrap();
+        write_msg(&mut stream, C_PING, &[]).expect("ping");
+        let (tag, _) = read_msg(&mut stream).expect("pong");
+        assert_eq!(tag, S_PONG);
+    }
+    let exited = daemon.shutdown_with_sigterm(Duration::from_secs(3));
+    assert!(exited, "daemon failed to exit within 3s of SIGTERM");
+    // After graceful shutdown, the socket file should be gone (cleanup ran).
+    assert!(
+        !daemon.sock.exists(),
+        "socket file still present after graceful shutdown: {}",
+        daemon.sock.display()
+    );
+}


### PR DESCRIPTION
## Summary

Closes the v0.6.0 milestone. 8 commits, ~1100 LOC of focused stability work + 4 end-to-end integration tests.

## Issues shipped

| # | Title | Commit |
|---|---|---|
| #8 | [BLOCKER] Worker thread panic isolation | `f939e4d` |
| #9 | [BLOCKER] OSC 52 + scrollback memory bounds | `dcd60a8` |
| #10 | [BLOCKER] Wire-protocol versioning + handshake | `e64cf59` |
| #11 | [CRITICAL] POSIX signal handling | `aaa8425` |
| #12 | Daemon integration test harness | `a7829e4` |

Plus precursor `fix(lint): collapse nested match guards (Rust 1.95)` to unstick CI on `main`.

## What changed (high-level)

- **Daemon survives any single-pane panic.** PTY/IPC/client reader threads wrapped with `catch_unwind`; the affected pane is marked dead with sentinel exit_code, daemon continues.
- **OSC 52 clipboard queue is now bounded** (16 entries / 256 KiB / 128 KiB single-sequence). Closes the obvious DoS vector against long-lived sessions.
- **Wire protocol carries a version + capability bitfield.** Mismatched majors are rejected with a clear "please upgrade" message instead of silent corruption. Backwards compatible — older clients without `C_HELLO` still work.
- **`SIGTERM` / `SIGHUP` save the snapshot before exiting**; `SIGCHLD` reaps zombie children.
- **First end-to-end tests** spawn `ezpn --server`, talk to it over a Unix socket, assert handshake + ping + signal lifecycle. Wire-protocol regressions now caught in CI.

## Pre-CI checklist

- [x] `cargo fmt -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` — 63 unit + 4 integration
- [x] `cargo build --release`

## Behavior verification

- [x] Manual: `target/release/ezpn 2 2`, attach/detach loop ×3 — no regressions
- [x] Manual: `kill -TERM <pid>` — daemon exits cleanly, snapshot file present
- [x] Integration: `cargo test --test daemon_lifecycle -- --test-threads=4` — 4/4 pass

## Risk

- **Snapshot schema unchanged** (still v2). v3 lands in #14.
- **Wire protocol additive only** — old clients keep working without `C_HELLO`.
- New `signal-hook` dep is well-maintained (rustsec audit clean).
- New `tempfile` dev-dep only used by tests.

## Reviewer focus

1. `src/server.rs::accept_client` — Hello negotiation path branch (lines around L500-580).
2. `src/pane.rs::push_osc52_capped` — order of cap checks (entries vs bytes).
3. `src/signals.rs` — `Signal::Terminate` path runs `WorkspaceSnapshot::from_live` then exits.
4. `tests/common.rs::DaemonHandle::Drop` — make sure SIGKILL path can never leak processes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)