### PR TITLE
fix(daemon): pane lifecycle GC — drop joins reader, close prunes maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Entries are written in **functional-only style**: every bullet describes an obse
 ### Added
 - **Scrollback memory hygiene** (#34): per-pane `[[pane]] scrollback_lines` override in `.ezpn.toml`, new `[scrollback]` config table (`default_lines`, `max_lines`, `warn_bytes`), runtime IPC commands `IpcRequest::ClearHistory` and `SetHistoryLimit`, matching `ezpn-ctl clear-history --pane N` and `ezpn-ctl set-scrollback --pane N --lines L` subcommands. Daemon emits a one-shot `WARN` log line when a pane's estimated scrollback exceeds the configured byte budget (default 50 MiB).
 
+### Fixed
+- **Pane lifecycle GC** (#35): `Pane` is now an RAII handle with a deterministic `Drop` that signals its reader thread to exit, releases the PTY master fd, and joins the reader within a 250 ms deadline (warns and `mem::forget`s on timeout). Field declaration order ensures `master` drops before `reader_handle` so the blocking `read()` unblocks via EOF. `close_pane` accepts and prunes `restart_policies`, `restart_state`, and `zoomed_pane`. `TabManager::kill_all_inactive` now drains `tab.panes` and clears per-tab restart bookkeeping. PTY reader threads are now named `ezpn-pty-<pid>` for diagnostics.
+
 ### Changed
 - **Daemon I/O resilience** (#33): each attached client now drains a bounded `mpsc::sync_channel(64)` through a dedicated writer thread with `set_write_timeout(50ms)`; clients are evicted after 3 consecutive `WouldBlock`/`TimedOut`. The IPC socket is now served by a fixed pool of 4 worker threads (`crossbeam-channel::bounded(16)`) with `set_read_timeout(5s)` + `set_write_timeout(2s)`; surplus connections receive `IpcResponse::error("ezpn ipc pool saturated; retry")` and idle peers receive `IpcResponse::error("idle timeout")`.
 

--- a/src/app/event_loop.rs
+++ b/src/app/event_loop.rs
@@ -537,7 +537,15 @@ pub(crate) fn run(stdout: &mut io::Stdout, config: &Config) -> anyhow::Result<()
                             // Close pane
                             KeyCode::Char('x') => {
                                 let target = active;
-                                close_pane(&mut layout, &mut panes, &mut active, target);
+                                close_pane(
+                                    &mut layout,
+                                    &mut panes,
+                                    &mut active,
+                                    target,
+                                    &mut restart_policies,
+                                    &mut restart_state,
+                                    &mut zoomed_pane,
+                                );
                                 resize_all(&mut panes, &layout, tw, th, &settings);
                                 update.mark_all(&layout);
                                 update.border_dirty = true;
@@ -854,7 +862,15 @@ pub(crate) fn run(stdout: &mut io::Stdout, config: &Config) -> anyhow::Result<()
                             {
                                 match action {
                                     render::TitleAction::Close(pid) => {
-                                        close_pane(&mut layout, &mut panes, &mut active, pid);
+                                        close_pane(
+                                            &mut layout,
+                                            &mut panes,
+                                            &mut active,
+                                            pid,
+                                            &mut restart_policies,
+                                            &mut restart_state,
+                                            &mut zoomed_pane,
+                                        );
                                         resize_all(&mut panes, &layout, tw, th, &settings);
                                     }
                                     render::TitleAction::SplitH(pid) => {
@@ -1096,6 +1112,9 @@ pub(crate) fn run(stdout: &mut io::Stdout, config: &Config) -> anyhow::Result<()
                     &mut settings,
                     effective_scrollback,
                     effective_max_scrollback,
+                    &mut restart_policies,
+                    &mut restart_state,
+                    &mut zoomed_pane,
                 );
                 update.merge(&mut ipc_update);
                 let _ = resp_tx.send(response);

--- a/src/app/input_dispatch.rs
+++ b/src/app/input_dispatch.rs
@@ -39,6 +39,9 @@ pub(crate) fn handle_ipc_command(
     settings: &mut Settings,
     scrollback: usize,
     max_scrollback: usize,
+    restart_policies: &mut HashMap<usize, project::RestartPolicy>,
+    restart_state: &mut HashMap<usize, (std::time::Instant, u32)>,
+    zoomed_pane: &mut Option<usize>,
 ) -> (ipc::IpcResponse, RenderUpdate) {
     let mut update = RenderUpdate::default();
 
@@ -68,7 +71,15 @@ pub(crate) fn handle_ipc_command(
             if !panes.contains_key(&pane) && !layout.pane_ids().contains(&pane) {
                 ipc::IpcResponse::error("pane not found")
             } else {
-                close_pane(layout, panes, active, pane);
+                close_pane(
+                    layout,
+                    panes,
+                    active,
+                    pane,
+                    restart_policies,
+                    restart_state,
+                    zoomed_pane,
+                );
                 resize_all(panes, layout, tw, th, settings);
                 update.mark_all(layout);
                 update.border_dirty = true;

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -369,16 +369,30 @@ pub(crate) fn do_split(
     Ok(())
 }
 
+/// Remove a pane from the layout and free every map keyed off its id.
+///
+/// Per SPEC 03 §4.2: dropping the pane out of `panes` triggers
+/// `Pane::Drop` which kills the child + joins the reader thread, so we no
+/// longer need an explicit `pane.kill()` here. The added `restart_*` and
+/// `zoomed_pane` arguments close the leak surface where these maps grew
+/// unboundedly with each split/close cycle.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn close_pane(
     layout: &mut Layout,
     panes: &mut HashMap<usize, Pane>,
     active: &mut usize,
     pane_id: usize,
+    restart_policies: &mut HashMap<usize, project::RestartPolicy>,
+    restart_state: &mut HashMap<usize, (std::time::Instant, u32)>,
+    zoomed_pane: &mut Option<usize>,
 ) {
-    if let Some(mut pane) = panes.remove(&pane_id) {
-        pane.kill();
-    }
+    panes.remove(&pane_id); // Drop fires here — see SPEC 03 §4.1.
     layout.remove(pane_id);
+    restart_policies.remove(&pane_id);
+    restart_state.remove(&pane_id);
+    if *zoomed_pane == Some(pane_id) {
+        *zoomed_pane = None;
+    }
     if *active == pane_id {
         *active = *layout.pane_ids().first().unwrap_or(&0);
     }

--- a/src/daemon/dispatch.rs
+++ b/src/daemon/dispatch.rs
@@ -47,6 +47,8 @@ pub(crate) fn process_event(
     tab_action: &mut TabAction,
     tab_names: &[(usize, String, bool)],
     prefix_key: char,
+    restart_policies: &mut HashMap<usize, crate::project::RestartPolicy>,
+    restart_state: &mut HashMap<usize, (Instant, u32)>,
 ) {
     match event {
         Event::Key(key) if key.kind == KeyEventKind::Press => {
@@ -69,6 +71,8 @@ pub(crate) fn process_event(
                 detach_requested,
                 tab_action,
                 prefix_key,
+                restart_policies,
+                restart_state,
             );
         }
         Event::Mouse(mouse) => {
@@ -102,6 +106,8 @@ pub(crate) fn process_event(
                     &inner,
                     tab_action,
                     tab_names,
+                    restart_policies,
+                    restart_state,
                 );
             }
         }
@@ -158,6 +164,8 @@ pub(super) fn execute_command(
     zoomed_pane: &mut Option<usize>,
     broadcast: &mut bool,
     tab_action: &mut TabAction,
+    restart_policies: &mut HashMap<usize, crate::project::RestartPolicy>,
+    restart_state: &mut HashMap<usize, (Instant, u32)>,
 ) {
     let parts: Vec<&str> = cmd.split_whitespace().collect();
     match parts.first().copied() {
@@ -192,7 +200,15 @@ pub(super) fn execute_command(
         }
         Some("kill-pane") | Some("close-pane") => {
             let target = *active;
-            crate::app::lifecycle::close_pane(layout, panes, active, target);
+            crate::app::lifecycle::close_pane(
+                layout,
+                panes,
+                active,
+                target,
+                restart_policies,
+                restart_state,
+                zoomed_pane,
+            );
             crate::app::lifecycle::resize_all(panes, layout, tw, th, settings);
             update.mark_all(layout);
             update.border_dirty = true;
@@ -281,6 +297,8 @@ pub(crate) fn process_mouse(
     inner: &Rect,
     tab_action: &mut TabAction,
     tab_names: &[(usize, String, bool)],
+    restart_policies: &mut HashMap<usize, crate::project::RestartPolicy>,
+    restart_state: &mut HashMap<usize, (Instant, u32)>,
 ) {
     match mouse.kind {
         MouseEventKind::Down(MouseButton::Left) => {
@@ -351,7 +369,15 @@ pub(crate) fn process_mouse(
             {
                 match action {
                     render::TitleAction::Close(pid) => {
-                        crate::app::lifecycle::close_pane(layout, panes, active, pid);
+                        crate::app::lifecycle::close_pane(
+                            layout,
+                            panes,
+                            active,
+                            pid,
+                            restart_policies,
+                            restart_state,
+                            zoomed_pane,
+                        );
                         crate::app::lifecycle::resize_all(panes, layout, tw, th, settings);
                     }
                     render::TitleAction::SplitH(pid) => {

--- a/src/daemon/event_loop.rs
+++ b/src/daemon/event_loop.rs
@@ -609,6 +609,8 @@ pub fn run(session_name: &str, args: &[String]) -> anyhow::Result<()> {
                             &mut tab_action,
                             &current_tab_names,
                             prefix_key,
+                            &mut restart_policies,
+                            &mut restart_state,
                         );
                     }
                     Ok(ClientMsg::Resize(w, h)) => {
@@ -1065,6 +1067,9 @@ pub fn run(session_name: &str, args: &[String]) -> anyhow::Result<()> {
                     &mut settings,
                     effective_scrollback,
                     effective_max_scrollback,
+                    &mut restart_policies,
+                    &mut restart_state,
+                    &mut zoomed_pane,
                 );
                 update.merge(&mut ipc_update);
                 let _ = resp_tx.send(response);

--- a/src/daemon/keys.rs
+++ b/src/daemon/keys.rs
@@ -15,6 +15,7 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use crate::config;
 use crate::layout::{Direction, Layout, NavDir};
 use crate::pane::{Pane, PaneLaunch};
+use crate::project;
 use crate::render::BorderCache;
 use crate::settings::{Settings, SettingsAction};
 
@@ -43,6 +44,8 @@ pub(crate) fn process_key(
     detach_requested: &mut bool,
     tab_action: &mut TabAction,
     prefix_key: char,
+    restart_policies: &mut HashMap<usize, project::RestartPolicy>,
+    restart_state: &mut HashMap<usize, (std::time::Instant, u32)>,
 ) {
     let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
     let alt = key.modifiers.contains(KeyModifiers::ALT);
@@ -82,7 +85,15 @@ pub(crate) fn process_key(
         match key.code {
             KeyCode::Char('y') | KeyCode::Enter => {
                 let target = *active;
-                crate::app::lifecycle::close_pane(layout, panes, active, target);
+                crate::app::lifecycle::close_pane(
+                    layout,
+                    panes,
+                    active,
+                    target,
+                    restart_policies,
+                    restart_state,
+                    zoomed_pane,
+                );
                 crate::app::lifecycle::resize_all(panes, layout, tw, th, settings);
                 update.mark_all(layout);
                 update.border_dirty = true;
@@ -179,6 +190,8 @@ pub(crate) fn process_key(
                     zoomed_pane,
                     broadcast,
                     tab_action,
+                    restart_policies,
+                    restart_state,
                 );
             }
             KeyCode::Esc => {

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::io::{Read, Write};
 use std::sync::mpsc::{self, Receiver, TryRecvError};
 use std::sync::OnceLock;
+use std::time::{Duration, Instant};
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
@@ -35,10 +36,27 @@ pub enum PaneLaunch {
     Command(String),
 }
 
+/// Per-pane state. Field declaration order is **load-bearing** for `Drop`:
+/// Rust drops fields top-to-bottom, so any field whose `Drop` must run
+/// before the reader thread is joined must appear *above* `reader_handle`.
+/// In particular `master` (the PTY master fd) drops before `reader_handle`
+/// so the blocking `reader.read()` unblocks on EOF before we try to join.
+/// See SPEC 03 `docs/spec/v0.10.0/03-lifecycle-gc.md` §4.1.
 pub struct Pane {
-    master: Box<dyn MasterPty + Send>,
-    writer: Box<dyn Write + Send>,
+    /// Child first so SIGHUP propagates before the master fd drops.
     child: Box<dyn Child + Send + Sync>,
+    writer: Box<dyn Write + Send>,
+    /// Send `()` to ask the reader to exit. `take()`-d in `Drop` so the
+    /// signal is idempotent. The reader also exits naturally on PTY EOF
+    /// (triggered by `master` dropping below); this signal just bounds
+    /// shutdown latency for slow / sleeping children.
+    shutdown_tx: Option<mpsc::SyncSender<()>>,
+    /// Drops here → kernel notices slave fd is closed → reader's blocking
+    /// `read()` returns 0 → reader exits → handle is joinable.
+    master: Box<dyn MasterPty + Send>,
+    /// `Some` until joined in `Drop`. If join exceeds the 250 ms deadline
+    /// the handle is `mem::forget`ed and a single warn line is emitted.
+    reader_handle: Option<std::thread::JoinHandle<()>>,
     reader_rx: Receiver<Vec<u8>>,
     parser: vt100::Parser,
     alive: bool,
@@ -163,46 +181,61 @@ impl Pane {
         let writer = pair.master.take_writer()?;
 
         let (tx, rx) = mpsc::sync_channel(32); // bounded: 32 * 4KB = 128KB max buffered
-        std::thread::spawn(move || {
-            // Isolate PTY-reader panics: a bad ANSI sequence or vt100 bug must not
-            // take down the daemon. On unwind the channel drops, which causes
-            // `read_output()` to observe `TryRecvError::Disconnected` and mark the
-            // pane dead with exit_code=u32::MAX (see `read_output`).
-            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                let mut reader = reader;
-                let mut buf = [0u8; 4096];
-                loop {
-                    match reader.read(&mut buf) {
-                        Ok(0) => break,
-                        Ok(n) => {
-                            if tx.send(buf[..n].to_vec()).is_err() {
-                                break;
-                            }
-                            wake_main_loop();
+        let (shutdown_tx, shutdown_rx) = mpsc::sync_channel::<()>(1);
+        let pid_for_name = child.process_id().unwrap_or(0);
+        let reader_handle = std::thread::Builder::new()
+            .name(format!("ezpn-pty-{pid_for_name}"))
+            .spawn(move || {
+                // Isolate PTY-reader panics: a bad ANSI sequence or vt100 bug
+                // must not take down the daemon. On unwind the channel drops,
+                // which causes `read_output()` to observe
+                // `TryRecvError::Disconnected` and mark the pane dead with
+                // exit_code=u32::MAX (see `read_output`).
+                let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    let mut reader = reader;
+                    let mut buf = [0u8; 4096];
+                    loop {
+                        // Cheap shutdown check between reads (SPEC 03 §4.1).
+                        // The blocking read below also unblocks when the
+                        // master fd drops, so this signal only bounds
+                        // shutdown latency for slow / sleeping children.
+                        if shutdown_rx.try_recv().is_ok() {
+                            break;
                         }
-                        Err(_) => break,
+                        match reader.read(&mut buf) {
+                            Ok(0) => break,
+                            Ok(n) => {
+                                if tx.send(buf[..n].to_vec()).is_err() {
+                                    break;
+                                }
+                                wake_main_loop();
+                            }
+                            Err(_) => break,
+                        }
                     }
+                }));
+                if let Err(payload) = result {
+                    let reason = match payload.downcast_ref::<&'static str>() {
+                        Some(s) => (*s).to_string(),
+                        None => match payload.downcast_ref::<String>() {
+                            Some(s) => s.clone(),
+                            None => "unknown panic payload".to_string(),
+                        },
+                    };
+                    eprintln!("ezpn: PTY reader thread panicked: {}", reason);
+                    wake_main_loop();
                 }
-            }));
-            if let Err(payload) = result {
-                let reason = match payload.downcast_ref::<&'static str>() {
-                    Some(s) => (*s).to_string(),
-                    None => match payload.downcast_ref::<String>() {
-                        Some(s) => s.clone(),
-                        None => "unknown panic payload".to_string(),
-                    },
-                };
-                eprintln!("ezpn: PTY reader thread panicked: {}", reason);
-                wake_main_loop();
-            }
-        });
+            })
+            .map_err(|e| anyhow::anyhow!("spawn ezpn-pty thread: {e}"))?;
 
         let parser = vt100::Parser::new(rows, cols, scrollback);
 
         Ok(Self {
-            master: pair.master,
-            writer,
             child,
+            writer,
+            shutdown_tx: Some(shutdown_tx),
+            master: pair.master,
+            reader_handle: Some(reader_handle),
             reader_rx: rx,
             parser,
             alive: true,
@@ -610,6 +643,49 @@ impl Pane {
             }
         }
         self.initial_cwd.clone()
+    }
+}
+
+/// SPEC 03 §4.1: deterministic shutdown for `Pane`. Steps run in declared
+/// order:
+/// 1. SIGHUP the child (idempotent — already dead is fine).
+/// 2. Signal the reader thread to exit (one-shot, idempotent).
+/// 3. Field drop order in `Pane` ensures `master` is released next,
+///    triggering EOF on the reader's blocking `read()`.
+/// 4. Bounded join: poll `is_finished()` for up to 250 ms, then either
+///    `join()` cleanly or `mem::forget` the handle and warn.
+impl Drop for Pane {
+    fn drop(&mut self) {
+        if self.alive {
+            let _ = self.child.kill();
+            self.alive = false;
+        }
+        if let Some(tx) = self.shutdown_tx.take() {
+            let _ = tx.try_send(());
+        }
+        // Capture pid *before* `master` drops — the warn-on-leak path needs
+        // a stable identifier and `child.process_id()` may surface a stale
+        // value once the kernel reaps the slot.
+        let pid = self.child.process_id().unwrap_or(0);
+        if let Some(handle) = self.reader_handle.take() {
+            // std::thread has no "join with timeout"; emulate via
+            // `is_finished()` polling. The reader exits via either the
+            // shutdown signal above, or PTY EOF when `master` drops as
+            // part of this struct's drop (after this block returns).
+            let deadline = Instant::now() + Duration::from_millis(250);
+            while !handle.is_finished() && Instant::now() < deadline {
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            if handle.is_finished() {
+                let _ = handle.join();
+            } else {
+                eprintln!(
+                    "ezpn: PTY reader thread for pid {pid} did not exit \
+                     within 250ms; leaking handle"
+                );
+                std::mem::forget(handle);
+            }
+        }
     }
 }
 
@@ -1040,6 +1116,42 @@ mod history_tests {
         assert!(
             scroll <= 100,
             "after shrink to cap=100, scrollback must be <= 100 (got {scroll})"
+        );
+    }
+}
+
+/// SPEC 03 §4.1: deterministic shutdown for `Pane`. The reader thread
+/// MUST exit within the bounded join window once the pane drops.
+#[cfg(test)]
+mod drop_tests {
+    // bench `render_hotpaths` includes pane.rs via `#[path]`; `super::*`
+    // ends up unused under that compilation unit. See snapshot_blob.rs
+    // for the same pattern.
+    #[allow(unused_imports)]
+    use super::*;
+
+    #[test]
+    fn pane_drop_joins_reader_within_500ms() {
+        // Spawn a real pane running a long-running command (`sleep 60`).
+        // Drop it and assert the reader thread is gone within the bounded
+        // window (allow 500ms in tests vs the production 250ms budget).
+        let pane = Pane::with_scrollback(
+            "/bin/sh",
+            PaneLaunch::Command("sleep 60".to_string()),
+            80,
+            24,
+            1000,
+        );
+        let pane = match pane {
+            Ok(p) => p,
+            Err(_) => return, // CI without /bin/sh is acceptable to skip.
+        };
+        let t0 = std::time::Instant::now();
+        drop(pane);
+        let elapsed = t0.elapsed();
+        assert!(
+            elapsed < Duration::from_millis(500),
+            "Pane::drop must complete within 500ms (got {elapsed:?})"
         );
     }
 }

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -168,12 +168,23 @@ impl TabManager {
         }
     }
 
-    /// Kill all panes in all inactive tabs (for session shutdown).
+    /// Kill all panes in all inactive tabs (for session shutdown). Per SPEC
+    /// 03 §4.3, drains `tab.panes` so each `Pane::Drop` fires (joining the
+    /// reader thread + releasing the master fd) and clears the per-tab
+    /// restart maps + zoomed state. Without the drain the tab retained
+    /// ~640 MB × N inactive tabs of vt100 RSS until the whole
+    /// `TabManager` itself dropped.
     pub fn kill_all_inactive(&mut self) {
         for tab in &mut self.tabs {
-            for pane in tab.panes.values_mut() {
+            // Send SIGHUP up-front so the reader thread can observe EOF
+            // while we're still iterating; `Pane::Drop` is idempotent and
+            // will skip the second kill call.
+            for (_, mut pane) in tab.panes.drain() {
                 pane.kill();
             }
+            tab.restart_policies.clear();
+            tab.restart_state.clear();
+            tab.zoomed_pane = None;
         }
     }
 
@@ -425,5 +436,37 @@ mod tests {
         assert_eq!(active.name, "only");
         assert_eq!(mgr.count, 1);
         assert_eq!(mgr.active_idx, 0);
+    }
+
+    /// SPEC 03 §4.3: `kill_all_inactive` drains `tab.panes` (releasing fds
+    /// and joining reader threads via `Pane::Drop`) and clears the per-tab
+    /// restart bookkeeping. We exercise the bookkeeping side without
+    /// spawning real PTYs by injecting a tab and seeding its restart maps.
+    #[test]
+    fn kill_all_inactive_clears_bookkeeping() {
+        let mut mgr = TabManager::new();
+        let mut tab = dummy_tab("syn");
+        tab.restart_policies
+            .insert(42, project::RestartPolicy::Always);
+        tab.restart_state.insert(42, (Instant::now(), 3));
+        tab.zoomed_pane = Some(42);
+        mgr.tabs.push(tab);
+
+        mgr.kill_all_inactive();
+
+        let cleaned = &mgr.tabs[0];
+        assert!(
+            cleaned.panes.is_empty(),
+            "kill_all_inactive must drain tab.panes"
+        );
+        assert!(
+            cleaned.restart_policies.is_empty(),
+            "restart_policies must be cleared"
+        );
+        assert!(
+            cleaned.restart_state.is_empty(),
+            "restart_state must be cleared"
+        );
+        assert!(cleaned.zoomed_pane.is_none(), "zoomed_pane must be reset");
     }
 }


### PR DESCRIPTION
## Summary

Closes #35. Third v0.10.0 stability fix.

`Pane` is now a fully-owned RAII handle with deterministic shutdown per [SPEC 03](https://github.com/subinium/ezpn/blob/main/docs/spec/v0.10.0/03-lifecycle-gc.md). Pane open/close cycles no longer leak threads, restart-map entries, or ~640 MB × N inactive tabs of vt100 RSS.

## Changes

### A. `Pane` shutdown protocol (SPEC 03 §4.1)
- `Pane` gains `shutdown_tx: Option<SyncSender<()>>` + `reader_handle: Option<JoinHandle<()>>`.
- Field declaration order is **load-bearing**: `master` drops before `reader_handle` so the blocking `read()` unblocks via EOF before we try to join.
- `impl Drop for Pane`:
  1. SIGHUP the child (idempotent).
  2. Signal the reader to exit.
  3. Drop the master fd in declared order.
  4. Poll `is_finished()` for up to 250 ms, then either join cleanly or `mem::forget` the handle and emit a single warn line.
- PTY reader threads now named `ezpn-pty-<pid>` for diagnostics.

### B. `close_pane` prunes maps (SPEC 03 §4.2)
- New parameters: `restart_policies: &mut HashMap`, `restart_state: &mut HashMap`, `zoomed_pane: &mut Option<usize>`.
- Explicit `pane.kill()` removed — `Pane::Drop` handles it.
- All 7 callers updated. `process_key`, `process_event`, `process_mouse`, `execute_command`, `handle_ipc_command` signatures extended to plumb the maps end-to-end.

### C. `kill_all_inactive` drains panes (SPEC 03 §4.3)
- `TabManager::kill_all_inactive` now drains `tab.panes` (so each `Pane::Drop` runs) and clears `tab.restart_policies`, `tab.restart_state`, `tab.zoomed_pane`.
- Eliminates the latent leak where a future non-exit caller (SPEC 08 hooks) would retain the full vt100 buffers.

## Acceptance criteria (from #35)
- [x] `Pane` holds `shutdown_tx` and `reader_handle`.
- [x] Field order ensures `master` drops before `reader_handle`.
- [x] PTY reader thread named `ezpn-pty-<pid>`.
- [x] `impl Drop for Pane` signals shutdown, joins with 250 ms deadline, warns + leaks on timeout.
- [x] `close_pane` removes entries from `restart_policies`, `restart_state`, clears `zoomed_pane` when matching.
- [x] All callers of `close_pane` pass the new arguments.
- [x] `kill_all_inactive` drains `tab.panes` and clears its restart maps.
- [x] No new clippy warnings; `cargo test` green.
- [x] No new external dep.

## Test plan
- [x] `cargo build` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` — **176 / 176 passing** (2 new tests):
  - `pane::drop_tests::pane_drop_joins_reader_within_500ms` (spawns real `sleep 60`, asserts shutdown < 500 ms)
  - `tab::tests::kill_all_inactive_clears_bookkeeping` (drain + clear path without PTYs)

## Wire protocol
Unchanged. Pure restructuring of existing types. No new external deps.

## Files
+290 / −44 across 9 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)