### PR TITLE
perf(daemon): async snapshot worker — debounced off-main writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Entries are written in **functional-only style**: every bullet describes an obse
 ### Fixed
 - **Pane lifecycle GC** (#35): `Pane` is now an RAII handle with a deterministic `Drop` that signals its reader thread to exit, releases the PTY master fd, and joins the reader within a 250 ms deadline (warns and `mem::forget`s on timeout). Field declaration order ensures `master` drops before `reader_handle` so the blocking `read()` unblocks via EOF. `close_pane` accepts and prunes `restart_policies`, `restart_state`, and `zoomed_pane`. `TabManager::kill_all_inactive` now drains `tab.panes` and clears per-tab restart bookkeeping. PTY reader threads are now named `ezpn-pty-<pid>` for diagnostics.
 
+### Performance
+- **Async snapshot pipeline** (#36): snapshot writes (and gzip+bincode for `persist_scrollback = true`) move off the daemon main loop into a dedicated `ezpn-snapshot` worker thread. Auto-saves are debounced with a 150 ms window so rapid attach/detach storms coalesce into ≤ 1 disk write per quiet period. User-initiated `ezpn-ctl save` keeps a synchronous-from-the-caller contract via an ack channel (30 s timeout); queue saturation surfaces a structured `IpcResponse::error("ezpn snapshot worker queue full; retry")`. Disk writes are atomic (temp file + rename). On `run()` return the worker drains pending captures within a 5 s deadline.
+
 ### Changed
 - **Daemon I/O resilience** (#33): each attached client now drains a bounded `mpsc::sync_channel(64)` through a dedicated writer thread with `set_write_timeout(50ms)`; clients are evicted after 3 consecutive `WouldBlock`/`TimedOut`. The IPC socket is now served by a fixed pool of 4 worker threads (`crossbeam-channel::bounded(16)`) with `set_read_timeout(5s)` + `set_write_timeout(2s)`; surplus connections receive `IpcResponse::error("ezpn ipc pool saturated; retry")` and idle peers receive `IpcResponse::error("idle timeout")`.
 

--- a/src/daemon/event_loop.rs
+++ b/src/daemon/event_loop.rs
@@ -20,6 +20,7 @@ use crate::daemon::dispatch::process_event;
 use crate::daemon::render::render_frame_to_buf;
 use crate::daemon::router::{accept_client, effective_size};
 use crate::daemon::snapshot::capture_workspace;
+use crate::daemon::snapshot_worker::{SnapshotJob, SnapshotWorker};
 use crate::daemon::state::{
     ClientMsg, ConnectedClient, DragState, InputMode, TabAction, TextSelection,
 };
@@ -105,6 +106,12 @@ pub fn run(session_name: &str, args: &[String]) -> anyhow::Result<()> {
     // SPEC 02 §4.5: pane IDs that have already crossed `scrollback_warn_bytes`
     // and emitted their one-shot warning. Reset is deferred (PRD non-goal).
     let mut scrollback_warned: HashSet<usize> = HashSet::new();
+
+    // SPEC 04: snapshot worker thread. Owns gzip+bincode + atomic write.
+    // Auto-saves are debounced (150 ms) and dropped on queue saturation;
+    // user `Save` IPC is acked synchronously. Drop on `run()` return
+    // flushes any pending auto with a 5 s deadline.
+    let snapshot_worker = SnapshotWorker::spawn();
 
     // Tab management
     use crate::tab::{Tab, TabManager};
@@ -749,7 +756,13 @@ pub fn run(session_name: &str, args: &[String]) -> anyhow::Result<()> {
                 effective_scrollback,
                 persist_scrollback,
             );
-            workspace::auto_save(session_name, &snapshot);
+            // SPEC 04: hand off to the worker — encode + atomic write
+            // happen off the main loop. Drop on saturation is deliberate
+            // (debounce will pick up the next idle).
+            let _ = snapshot_worker.submit(SnapshotJob::Auto {
+                session_name: session_name.to_string(),
+                snapshot,
+            });
             mode = InputMode::Normal;
             drag = None;
             selection_anchor = None;
@@ -961,9 +974,22 @@ pub fn run(session_name: &str, args: &[String]) -> anyhow::Result<()> {
                         effective_scrollback,
                         persist_scrollback,
                     );
-                    let response = match workspace::save_snapshot(path, &snapshot) {
-                        Ok(()) => ipc::IpcResponse::success(format!("saved {}", path)),
-                        Err(error) => ipc::IpcResponse::error(error.to_string()),
+                    // SPEC 04 §4.3: user-initiated save → worker with ack.
+                    let (ack_tx, ack_rx) = mpsc::sync_channel(1);
+                    let submitted = snapshot_worker.submit(SnapshotJob::UserSave {
+                        path: std::path::PathBuf::from(path),
+                        snapshot,
+                        ack: ack_tx,
+                    });
+                    let response = if !submitted {
+                        ipc::IpcResponse::error("snapshot worker queue full; retry")
+                    } else {
+                        match ack_rx.recv_timeout(crate::daemon::snapshot_worker::USER_SAVE_TIMEOUT)
+                        {
+                            Ok(Ok(())) => ipc::IpcResponse::success(format!("saved {}", path)),
+                            Ok(Err(e)) => ipc::IpcResponse::error(e),
+                            Err(_) => ipc::IpcResponse::error("snapshot worker timed out"),
+                        }
                     };
                     let _ = resp_tx.send(response);
                     continue;
@@ -1211,7 +1237,10 @@ pub fn run(session_name: &str, args: &[String]) -> anyhow::Result<()> {
                             effective_scrollback,
                             persist_scrollback,
                         );
-                        workspace::auto_save(session_name, &snapshot);
+                        let _ = snapshot_worker.submit(SnapshotJob::Auto {
+                            session_name: session_name.to_string(),
+                            snapshot,
+                        });
                         for pane in panes.values_mut() {
                             pane.kill();
                         }

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -18,6 +18,7 @@ pub(crate) mod keys;
 pub(crate) mod render;
 pub(crate) mod router;
 pub(crate) mod snapshot;
+pub(crate) mod snapshot_worker;
 pub(crate) mod state;
 pub(crate) mod writer;
 

--- a/src/daemon/snapshot_worker.rs
+++ b/src/daemon/snapshot_worker.rs
@@ -1,0 +1,311 @@
+//! Snapshot worker thread that drains a bounded queue of capture-and-write
+//! jobs off the daemon main loop.
+//!
+//! Per SPEC 04 `docs/spec/v0.10.0/04-snapshot-pipeline-async.md`:
+//!
+//! * **Bounded mpsc(4)** between main and worker — `try_send` returning
+//!   `Full` is a deliberate drop, not an error: rapid detach/attach storms
+//!   coalesce into the next idle window.
+//! * **Debounce 150 ms** — a freshly arrived `Auto` job replaces any
+//!   pending one without writing to disk until the window elapses.
+//! * **Atomic write** — temp file + rename, so a SIGKILL during write
+//!   never produces a half-written snapshot.
+//! * **Bounded shutdown** — `shutdown()` sends a `Shutdown` sentinel and
+//!   waits up to 5 s for the worker to drain. On timeout the handle is
+//!   `mem::forget`ed and a single warn line is emitted (the OS reaps the
+//!   thread on process exit).
+
+use std::path::{Path, PathBuf};
+use std::sync::mpsc;
+use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
+
+use crate::workspace::{self, WorkspaceSnapshot};
+
+/// How long the worker waits before flushing a coalesced `Auto` job.
+pub(crate) const DEBOUNCE: Duration = Duration::from_millis(150);
+
+/// Maximum number of pending jobs the main loop can queue without back-
+/// pressure. With debounce this is effectively a small absorption buffer.
+pub(crate) const QUEUE_CAPACITY: usize = 4;
+
+/// Maximum time `SnapshotWorker::shutdown` will wait for the worker to
+/// drain pending writes before leaking the handle.
+pub(crate) const SHUTDOWN_DEADLINE: Duration = Duration::from_secs(5);
+
+/// Maximum time `IpcRequest::Save` will wait for the worker to ack a
+/// user-initiated save before returning a structured error.
+pub(crate) const USER_SAVE_TIMEOUT: Duration = Duration::from_secs(30);
+
+pub(crate) enum SnapshotJob {
+    /// Auto-save fired by detach / SIGTERM / KillSession. Coalesced via
+    /// `DEBOUNCE` window so attach/detach storms do not hammer disk.
+    Auto {
+        session_name: String,
+        snapshot: WorkspaceSnapshot,
+    },
+    /// User-initiated `ezpn-ctl save`. Bypasses the debounce window and
+    /// signals completion via the ack channel.
+    UserSave {
+        path: PathBuf,
+        snapshot: WorkspaceSnapshot,
+        ack: mpsc::SyncSender<Result<(), String>>,
+    },
+    /// Drain any pending `Auto` then exit. Used by `shutdown()`.
+    Shutdown,
+}
+
+pub(crate) struct SnapshotWorker {
+    tx: mpsc::SyncSender<SnapshotJob>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl SnapshotWorker {
+    /// Spawn the worker. One per daemon process.
+    pub(crate) fn spawn() -> Self {
+        let (tx, rx) = mpsc::sync_channel::<SnapshotJob>(QUEUE_CAPACITY);
+        let handle = std::thread::Builder::new()
+            .name("ezpn-snapshot".into())
+            .spawn(move || run(rx))
+            .expect("spawn ezpn-snapshot thread");
+        Self {
+            tx,
+            handle: Some(handle),
+        }
+    }
+
+    /// Best-effort enqueue. Returns `false` if the queue is saturated;
+    /// the caller should treat that as a deliberate drop, not an error.
+    pub(crate) fn submit(&self, job: SnapshotJob) -> bool {
+        self.tx.try_send(job).is_ok()
+    }
+
+    /// Bounded shutdown: send `Shutdown`, wait up to `SHUTDOWN_DEADLINE`.
+    /// Idempotent — `Drop` calls the same machinery if the caller never
+    /// invokes it explicitly.
+    #[cfg(test)]
+    pub(crate) fn shutdown(mut self) {
+        drain_and_join(&self.tx, self.handle.take());
+    }
+}
+
+impl Drop for SnapshotWorker {
+    fn drop(&mut self) {
+        // Daemon shutdown path: send the `Shutdown` sentinel so any pending
+        // `Auto` capture is flushed, then poll-join the worker within
+        // `SHUTDOWN_DEADLINE`. If `shutdown()` was called explicitly the
+        // handle is already `None` and this is a no-op.
+        drain_and_join(&self.tx, self.handle.take());
+    }
+}
+
+fn drain_and_join(tx: &mpsc::SyncSender<SnapshotJob>, handle: Option<JoinHandle<()>>) {
+    let Some(h) = handle else { return };
+    let _ = tx.send(SnapshotJob::Shutdown);
+    let deadline = Instant::now() + SHUTDOWN_DEADLINE;
+    while !h.is_finished() && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    if h.is_finished() {
+        let _ = h.join();
+    } else {
+        eprintln!("ezpn: snapshot worker did not drain within 5s; leaking handle");
+        std::mem::forget(h);
+    }
+}
+
+fn run(rx: mpsc::Receiver<SnapshotJob>) {
+    // Pending auto-save: (session_name, snapshot, debounce_start).
+    let mut pending: Option<(String, WorkspaceSnapshot, Instant)> = None;
+    loop {
+        // No pending → block indefinitely. Pending → block at most until
+        // the debounce window expires so we can flush it.
+        let timeout = pending
+            .as_ref()
+            .map(|(_, _, t0)| (*t0 + DEBOUNCE).saturating_duration_since(Instant::now()))
+            .unwrap_or(Duration::from_secs(60 * 60));
+
+        match rx.recv_timeout(timeout) {
+            Ok(SnapshotJob::Auto {
+                session_name,
+                snapshot,
+            }) => {
+                // Debounce: replace any pending capture with the latest.
+                pending = Some((session_name, snapshot, Instant::now()));
+            }
+            Ok(SnapshotJob::UserSave {
+                path,
+                snapshot,
+                ack,
+            }) => {
+                let result = write_user_snapshot(&path, &snapshot).map_err(|e| e.to_string());
+                let _ = ack.send(result);
+            }
+            Ok(SnapshotJob::Shutdown) => {
+                if let Some((session, snapshot, _)) = pending.take() {
+                    workspace::auto_save(&session, &snapshot);
+                }
+                return;
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                if let Some((session, snapshot, _)) = pending.take() {
+                    workspace::auto_save(&session, &snapshot);
+                }
+            }
+            Err(mpsc::RecvTimeoutError::Disconnected) => return,
+        }
+    }
+}
+
+/// Write a user snapshot to an arbitrary `path` atomically (temp file +
+/// rename). Used by `SnapshotJob::UserSave`.
+fn write_user_snapshot(path: &Path, snapshot: &WorkspaceSnapshot) -> anyhow::Result<()> {
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)?;
+        }
+    }
+    let json = serde_json::to_vec_pretty(snapshot)?;
+    let pid = std::process::id();
+    let file_name = path
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "snapshot.json".to_string());
+    let tmp = path.with_file_name(format!("{file_name}.tmp.{pid}"));
+    if let Err(e) = std::fs::write(&tmp, &json) {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(e.into());
+    }
+    if let Err(e) = std::fs::rename(&tmp, path) {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(e.into());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+
+    /// Serializes tests that mutate process-global `XDG_DATA_HOME` so they
+    /// don't race when cargo runs them in parallel. Same pattern as
+    /// `config::tests::ENV_LOCK`.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn dummy_snapshot() -> WorkspaceSnapshot {
+        // Build a minimal valid snapshot via the public constructor path.
+        // We only need *a* WorkspaceSnapshot to exercise the worker pipeline.
+        WorkspaceSnapshot {
+            version: workspace::SNAPSHOT_VERSION,
+            shell: "/bin/sh".to_string(),
+            border_style: crate::render::BorderStyle::Single,
+            show_status_bar: true,
+            show_tab_bar: true,
+            scrollback: 1000,
+            active_tab: 0,
+            tabs: vec![workspace::TabSnapshot {
+                name: "1".to_string(),
+                layout: crate::layout::Layout::from_grid(1, 1),
+                active_pane: 0,
+                zoomed_pane: None,
+                broadcast: false,
+                panes: vec![],
+            }],
+        }
+    }
+
+    #[test]
+    fn worker_writes_user_save_atomically() {
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("save.json");
+        let worker = SnapshotWorker::spawn();
+        let (ack_tx, ack_rx) = mpsc::sync_channel(1);
+        let ok = worker.submit(SnapshotJob::UserSave {
+            path: dest.clone(),
+            snapshot: dummy_snapshot(),
+            ack: ack_tx,
+        });
+        assert!(ok);
+        let result = ack_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+        assert!(result.is_ok(), "user save must succeed: {result:?}");
+        assert!(dest.exists(), "atomic rename must produce final file");
+        // No leftover *.tmp.* siblings.
+        let leftovers: Vec<_> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .flatten()
+            .filter(|e| e.file_name().to_string_lossy().contains(".tmp."))
+            .collect();
+        assert!(leftovers.is_empty(), "no .tmp.* files: {leftovers:?}");
+        worker.shutdown();
+    }
+
+    #[test]
+    fn worker_shutdown_drains_pending_auto() {
+        // Serialize against other tests that mutate XDG_DATA_HOME.
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = tempfile::tempdir().unwrap();
+        unsafe {
+            std::env::set_var("XDG_DATA_HOME", dir.path());
+        }
+        let session = format!("worker-shutdown-{}", std::process::id());
+        let worker = SnapshotWorker::spawn();
+        worker.submit(SnapshotJob::Auto {
+            session_name: session.clone(),
+            snapshot: dummy_snapshot(),
+        });
+        worker.shutdown();
+        let expected = dir
+            .path()
+            .join("ezpn")
+            .join("sessions")
+            .join(format!("{session}.json"));
+        assert!(
+            expected.exists(),
+            "shutdown must drain pending Auto to {expected:?}"
+        );
+        unsafe {
+            std::env::remove_var("XDG_DATA_HOME");
+        }
+    }
+
+    #[test]
+    fn worker_debounces_rapid_auto_jobs() {
+        // Serialize against other tests that mutate XDG_DATA_HOME.
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        // Send 5 Auto jobs in quick succession; only the last one should
+        // hit disk after the debounce window.
+        let dir = tempfile::tempdir().unwrap();
+        unsafe {
+            std::env::set_var("XDG_DATA_HOME", dir.path());
+        }
+        let session = format!("worker-debounce-{}", std::process::id());
+        let worker = SnapshotWorker::spawn();
+        let send_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        for _ in 0..5 {
+            if worker.submit(SnapshotJob::Auto {
+                session_name: session.clone(),
+                snapshot: dummy_snapshot(),
+            }) {
+                send_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            }
+            // Stay well inside the debounce window.
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        // Wait for debounce window + slack.
+        std::thread::sleep(DEBOUNCE + Duration::from_millis(150));
+        let path = dir
+            .path()
+            .join("ezpn")
+            .join("sessions")
+            .join(format!("{session}.json"));
+        assert!(path.exists(), "debounced auto-save must reach disk");
+        // Modification times are not stable enough across filesystems to
+        // assert "exactly 1 write" — instead assert the file is final and
+        // the worker drains cleanly.
+        worker.shutdown();
+        unsafe {
+            std::env::remove_var("XDG_DATA_HOME");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #36. Fourth v0.10.0 stability fix.

Snapshot writes (and gzip+bincode for `persist_scrollback = true`) move off the daemon main loop into a dedicated `ezpn-snapshot` worker thread. Per [SPEC 04](https://github.com/subinium/ezpn/blob/main/docs/spec/v0.10.0/04-snapshot-pipeline-async.md).

## Changes

### A. New worker module — `src/daemon/snapshot_worker.rs` (~290 LoC)
- `SnapshotWorker` thread named `ezpn-snapshot`.
- Bounded `mpsc::sync_channel(4)`; `try_send` returning `Full` is a deliberate drop (debounce coalesces on the next idle).
- 150 ms debounce window: a freshly arrived `Auto` job replaces any pending one; the worker only writes when the window elapses.
- User-initiated `Save` jobs bypass the debounce and signal completion via an ack channel (30 s timeout).
- Atomic write: `path.with_file_name("{name}.tmp.{pid}")` + `rename`.
- `Drop` impl drains any pending `Auto` and joins the thread within a 5 s deadline; on timeout the handle is `mem::forget`ed and a single warn line is emitted.

### B. Wiring — `src/daemon/event_loop.rs`
- `SnapshotWorker::spawn()` near other init.
- Three `workspace::auto_save(...)` sites → `submit(SnapshotJob::Auto)`.
- IPC `Save` site → `submit(SnapshotJob::UserSave)` + bounded ack `recv_timeout`; saturation/timeout return structured errors via `IpcResponse::error(...)`.

## Acceptance criteria (from #36)
- [x] `SnapshotWorker` spawned at daemon bring-up; one named thread `ezpn-snapshot`.
- [x] Auto-save path uses bounded `mpsc::sync_channel(4)` and `try_send`.
- [x] Debounce window of 150 ms coalesces rapid `Auto` jobs.
- [x] User-initiated `Save` jobs bypass debounce and surface result via an ack channel.
- [x] Atomic write (tmp file + rename) used for both auto-save and user save.
- [x] On `run()` return the worker drains pending captures within a 5 s deadline (via `Drop`).
- [x] Snapshot v3 on-disk schema unchanged.
- [x] No new clippy warnings; `cargo test` green.
- [x] PROTOCOL_VERSION unchanged.

## Test plan
- [x] `cargo build` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` — **180 / 180 passing** (3 new unit tests):
  - `worker_writes_user_save_atomically` (no `.tmp.*` leftovers)
  - `worker_shutdown_drains_pending_auto`
  - `worker_debounces_rapid_auto_jobs`

## Wire protocol & schema
Wire protocol unchanged. On-disk snapshot schema unchanged (`v3`). No new external deps.

## Files
+349 / −5 across 4 files. New: `src/daemon/snapshot_worker.rs` (~290 LoC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)