### PR TITLE
feat(daemon): send-keys api — keyspec parser + ipc + ezpn-ctl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Entries are written in **functional-only style**: every bullet describes an obse
 ## [Unreleased]
 
 ### Added
+- **`send-keys` API** (#38): new `ezpn-ctl send-keys [--pane N | --target current] [--literal] -- <key>...` subcommand and matching `IpcRequest::SendKeys` variant deliver chord-token sequences (or raw bytes via `--literal`) into a pane's PTY write half. KeySpec grammar in `src/keymap/keyspec.rs` covers Ctrl/Alt/Shift modifiers and the standard Named keys (Enter, Tab, Esc, Space, Backspace, Delete, arrows, Home/End, PageUp/PageDown, F1–F12). `--literal` writes bytes verbatim and rejects tokens that would compile to a Named key with `--literal forbids named keys (got 'X')`. Wire format uses `keys: Vec<String>` to keep multi-char literal arguments unambiguous; `IpcResponse::message` reports `"sent N bytes"` on success. No protocol bump.
 - **Scrollback memory hygiene** (#34): per-pane `[[pane]] scrollback_lines` override in `.ezpn.toml`, new `[scrollback]` config table (`default_lines`, `max_lines`, `warn_bytes`), runtime IPC commands `IpcRequest::ClearHistory` and `SetHistoryLimit`, matching `ezpn-ctl clear-history --pane N` and `ezpn-ctl set-scrollback --pane N --lines L` subcommands. Daemon emits a one-shot `WARN` log line when a pane's estimated scrollback exceeds the configured byte budget (default 50 MiB).
 
 ### Fixed

--- a/src/app/input_dispatch.rs
+++ b/src/app/input_dispatch.rs
@@ -21,6 +21,7 @@ use crate::app::lifecycle::{
 use crate::app::render_ctl::make_inner;
 use crate::app::state::RenderUpdate;
 use crate::ipc;
+use crate::keymap::keyspec;
 use crate::layout::{Direction, Layout};
 use crate::pane::{Pane, PaneLaunch};
 use crate::project;
@@ -267,7 +268,73 @@ pub(crate) fn handle_ipc_command(
                 ipc::IpcResponse::error(format!("no pane {pane}"))
             }
         }
+        ipc::IpcRequest::SendKeys {
+            target,
+            keys,
+            literal,
+        } => handle_send_keys(panes, *active, target, keys, literal),
     };
 
     (response, update)
+}
+
+/// SPEC 06 §4 — `send-keys` dispatch.
+///
+/// Resolves the target pane, optionally compiles the chord-token list into
+/// raw PTY bytes (`literal=false`) or concatenates them verbatim
+/// (`literal=true`), and writes the result through `Pane::write_bytes`. The
+/// success message reports the byte count for debugging visibility.
+fn handle_send_keys(
+    panes: &mut HashMap<usize, Pane>,
+    active: usize,
+    target: ipc::PaneTarget,
+    tokens: Vec<String>,
+    literal: bool,
+) -> ipc::IpcResponse {
+    if tokens.is_empty() {
+        return ipc::IpcResponse::error("no keys to send");
+    }
+    let total_bytes: usize = tokens.iter().map(|s| s.len()).sum();
+    if total_bytes > ipc::SEND_KEYS_MAX_BYTES {
+        return ipc::IpcResponse::error(format!(
+            "send-keys payload too large ({total_bytes} > {} bytes)",
+            ipc::SEND_KEYS_MAX_BYTES
+        ));
+    }
+
+    let pane_id = match target {
+        ipc::PaneTarget::Id { value } => value,
+        ipc::PaneTarget::Current => active,
+    };
+
+    let bytes = if literal {
+        // Per SPEC §4.5, literal mode forbids token strings that would
+        // otherwise compile to a Named key — surfaces the user's intent
+        // mismatch ("did you mean to press Enter or send the 5 letters
+        // E-n-t-e-r?") rather than silently writing raw bytes.
+        if let Some(named) = tokens.iter().find(|t| keyspec::is_named_key(t)) {
+            return ipc::IpcResponse::error(format!(
+                "--literal forbids named keys (got '{named}')"
+            ));
+        }
+        let mut out = Vec::with_capacity(total_bytes);
+        for tok in &tokens {
+            out.extend_from_slice(tok.as_bytes());
+        }
+        out
+    } else {
+        match keyspec::compile_to_bytes(&tokens) {
+            Ok(bytes) => bytes,
+            Err(error) => return ipc::IpcResponse::error(format!("parse: {error}")),
+        }
+    };
+
+    let Some(pane) = panes.get_mut(&pane_id) else {
+        return ipc::IpcResponse::error(format!("pane {pane_id} not found"));
+    };
+    if !pane.is_alive() {
+        return ipc::IpcResponse::error(format!("pane {pane_id} not alive"));
+    }
+    pane.write_bytes(&bytes);
+    ipc::IpcResponse::success(format!("sent {} bytes", bytes.len()))
 }

--- a/src/bin/ezpn-ctl.rs
+++ b/src/bin/ezpn-ctl.rs
@@ -155,9 +155,73 @@ fn parse_request(args: &[String]) -> anyhow::Result<ipc::IpcRequest> {
             pane: parse_flag_pane(args)?,
             lines: parse_flag_lines(args)?,
         }),
+        Some("send-keys") => parse_send_keys(args),
         Some(other) => anyhow::bail!("unknown command: {}", other),
         None => anyhow::bail!("missing command"),
     }
+}
+
+/// Parse `ezpn-ctl send-keys [--pane N | --target current] [--literal] -- <key>...`.
+///
+/// Per SPEC 06 §5: the `--` separator is mandatory once any `<key>` could
+/// look like a flag. We require it unconditionally to keep the contract
+/// simple and unambiguous (matches `git`'s convention).
+fn parse_send_keys(args: &[String]) -> anyhow::Result<ipc::IpcRequest> {
+    // Find the `--` separator; everything after it is `<key>` tokens.
+    let dash_dash = args.iter().position(|a| a == "--").ok_or_else(|| {
+        anyhow::anyhow!(
+            "send-keys requires `--` before key tokens (e.g. \
+             `ezpn-ctl send-keys --pane 0 -- 'echo hi' Enter`)"
+        )
+    })?;
+    let opts = &args[1..dash_dash];
+    let keys: Vec<String> = args[dash_dash + 1..].to_vec();
+    if keys.is_empty() {
+        anyhow::bail!("send-keys requires at least one key after `--`");
+    }
+
+    let mut pane_id: Option<usize> = None;
+    let mut current = false;
+    let mut literal = false;
+    let mut i = 0;
+    while i < opts.len() {
+        match opts[i].as_str() {
+            "--pane" => {
+                i += 1;
+                let v = opts
+                    .get(i)
+                    .ok_or_else(|| anyhow::anyhow!("--pane requires a number"))?;
+                pane_id = Some(v.parse()?);
+            }
+            "--target" => {
+                i += 1;
+                let v = opts
+                    .get(i)
+                    .ok_or_else(|| anyhow::anyhow!("--target requires a value"))?;
+                if v != "current" {
+                    anyhow::bail!("only --target current is supported in v0.10");
+                }
+                current = true;
+            }
+            "--literal" => literal = true,
+            other => anyhow::bail!("unknown send-keys option: {}", other),
+        }
+        i += 1;
+    }
+    if pane_id.is_some() && current {
+        anyhow::bail!("--pane and --target current are mutually exclusive");
+    }
+    let target = match (pane_id, current) {
+        (Some(id), false) => ipc::PaneTarget::Id { value: id },
+        (None, true) => ipc::PaneTarget::Current,
+        (None, false) => anyhow::bail!("send-keys requires --pane <N> or --target current"),
+        (Some(_), true) => unreachable!(),
+    };
+    Ok(ipc::IpcRequest::SendKeys {
+        target,
+        keys,
+        literal,
+    })
 }
 
 /// Parse a required `--pane N` flag from the args after the subcommand.
@@ -267,6 +331,11 @@ COMMANDS:
   set-scrollback --pane N --lines L
                              Resize a pane's scrollback ring (max from
                              [scrollback] max_lines, default 100000)
+  send-keys [--pane N | --target current] [--literal] -- <key>...
+                             Deliver keystrokes/text into a pane's PTY.
+                             Each <key> is a chord token: 'C-a', 'Enter',
+                             'F5', or literal text like 'echo hi'.
+                             --literal writes bytes verbatim (no parsing).
 
 EXAMPLES:
   ezpn-ctl list
@@ -274,6 +343,9 @@ EXAMPLES:
   ezpn-ctl save .ezpn-session.json
   ezpn-ctl --pid 12345 load .ezpn-session.json
   ezpn-ctl clear-history --pane 0
-  ezpn-ctl set-scrollback --pane 0 --lines 5000"
+  ezpn-ctl set-scrollback --pane 0 --lines 5000
+  ezpn-ctl send-keys --pane 0 -- 'echo hello' Enter
+  ezpn-ctl send-keys --target current -- C-c
+  ezpn-ctl send-keys --pane 2 -- C-x C-s"
     );
 }

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -23,11 +23,29 @@ pub(crate) const IPC_READ_TIMEOUT: Duration = Duration::from_secs(5);
 /// `IpcResponse` on a misbehaving peer.
 pub(crate) const IPC_WRITE_TIMEOUT: Duration = Duration::from_secs(2);
 
+/// Maximum size of a single `send-keys` payload (sum of all token bytes).
+/// Mirrors the existing 16 MiB protocol payload cap from `protocol.rs` so a
+/// hostile script cannot flood a pane in one IPC round-trip. Per SPEC 06 §10.
+pub(crate) const SEND_KEYS_MAX_BYTES: usize = 16 * 1024 * 1024;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SplitDirection {
     Horizontal,
     Vertical,
+}
+
+/// Where a SPEC 06 `send-keys` payload should land. The enum keeps the wire
+/// format forward-compatible with future targeting modes (by-name, by-index,
+/// cross-tab) without breaking existing CLI consumers.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum PaneTarget {
+    /// Numeric pane ID as shown by `ezpn-ctl list`.
+    Id { value: usize },
+    /// The active pane on the active tab — resolved server-side at dispatch
+    /// time, so there is no race between resolution and delivery.
+    Current,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -67,6 +85,18 @@ pub enum IpcRequest {
     SetHistoryLimit {
         pane: usize,
         lines: usize,
+    },
+    /// Deliver a sequence of keystrokes / text into a pane's PTY write half.
+    /// Per SPEC 06: tokens are concatenated with no separator between them,
+    /// and parsed via `keymap::keyspec` unless `literal` is set (in which
+    /// case the bytes are written verbatim). Wire field uses a serde-default
+    /// for `literal` so older `ezpn-ctl` builds that omit the flag still
+    /// deserialize cleanly.
+    SendKeys {
+        target: PaneTarget,
+        keys: Vec<String>,
+        #[serde(default)]
+        literal: bool,
     },
 }
 

--- a/src/keymap/keyspec.rs
+++ b/src/keymap/keyspec.rs
@@ -1,0 +1,367 @@
+//! KeySpec grammar — text → raw PTY bytes.
+//!
+//! Per SPEC 06 §4.2 (`docs/spec/v0.10.0/06-send-keys-api.md`) the grammar is:
+//!
+//! ```text
+//! KeySpec  ← Chord (WS Chord)*
+//! Chord    ← (Modifier '-')* Atom
+//! Modifier ← 'C' / 'M' / 'S'
+//! Atom     ← Named / Char+
+//! Named    ← Enter | Tab | Esc | Space | Backspace | Delete
+//!          | Up | Down | Left | Right
+//!          | Home | End | PageUp | PageDown
+//!          | F1 .. F12
+//! ```
+//!
+//! The wire format carries `keys: Vec<String>` — one element per chord
+//! token, matching CLI argv after `--`. This is a deliberate deviation
+//! from the SPEC's draft single-string example: a vector eliminates
+//! escape ambiguity for multi-char literal arguments like `'echo hi'`.
+//!
+//! Untouched-by-SPEC quirks worth knowing:
+//! * `Enter` emits `\r` (0x0D) — what an unmodified terminal sends, not `\n`.
+//! * `Backspace` emits `\x7f` (DEL) — the xterm default.
+//! * Modifier+Named is intentionally narrow: only `S-Tab`, `M-Tab`, and
+//!   `M-<arrow>` style "Alt-prefixed Named" sequences. Other combinations
+//!   return a structured `ParseError`; users can fall back to `--literal`.
+//! * `is_named_key` lets the dispatch layer enforce SPEC §4.5's
+//!   "literal forbids named keys" rule without re-parsing.
+
+use std::fmt;
+
+/// Structured parse failure. Display string is what `IpcResponse::error`
+/// surfaces to `ezpn-ctl`, so it is end-user-facing.
+#[derive(Debug, Clone)]
+pub struct ParseError {
+    msg: String,
+}
+
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.msg)
+    }
+}
+
+impl std::error::Error for ParseError {}
+
+/// Compile a CLI-style chord token list into the byte sequence that
+/// pressing those keys interactively would deliver to the PTY.
+///
+/// Tokens are concatenated with no separator between them, so
+/// `["echo", "Space", "hi", "Enter"]` yields `b"echo hi\r"` (Space is the
+/// Named key, not a separator).
+pub fn compile_to_bytes(tokens: &[String]) -> Result<Vec<u8>, ParseError> {
+    if tokens.is_empty() {
+        return Err(err("no keys to send"));
+    }
+    let mut out = Vec::new();
+    for tok in tokens {
+        compile_token(tok, &mut out)?;
+    }
+    Ok(out)
+}
+
+/// True iff `token` would compile as a Named key (Enter, Tab, F5, …).
+/// Used by the dispatch layer to enforce the literal-mode guard.
+pub fn is_named_key(token: &str) -> bool {
+    lookup_named(token).is_some()
+}
+
+fn compile_token(token: &str, out: &mut Vec<u8>) -> Result<(), ParseError> {
+    if token.is_empty() {
+        return Err(err("empty chord"));
+    }
+    if token.contains('\n') {
+        return Err(err(
+            "newline in non-literal token; use 'Enter' or --literal",
+        ));
+    }
+    if let Some((mods, atom)) = try_split_chord(token)? {
+        emit_chord(&mods, atom, out)?;
+        return Ok(());
+    }
+    if let Some(bytes) = lookup_named(token) {
+        out.extend_from_slice(bytes);
+        return Ok(());
+    }
+    // Multi-char or non-named single-char: treat as literal UTF-8 text.
+    out.extend_from_slice(token.as_bytes());
+    Ok(())
+}
+
+const NAMED_KEYS: &[(&str, &[u8])] = &[
+    ("Enter", b"\r"),
+    ("Tab", b"\t"),
+    ("Esc", b"\x1b"),
+    ("Space", b" "),
+    ("Backspace", b"\x7f"),
+    ("Delete", b"\x1b[3~"),
+    ("Up", b"\x1b[A"),
+    ("Down", b"\x1b[B"),
+    ("Left", b"\x1b[D"),
+    ("Right", b"\x1b[C"),
+    ("Home", b"\x1b[H"),
+    ("End", b"\x1b[F"),
+    ("PageUp", b"\x1b[5~"),
+    ("PageDown", b"\x1b[6~"),
+    ("F1", b"\x1bOP"),
+    ("F2", b"\x1bOQ"),
+    ("F3", b"\x1bOR"),
+    ("F4", b"\x1bOS"),
+    ("F5", b"\x1b[15~"),
+    ("F6", b"\x1b[17~"),
+    ("F7", b"\x1b[18~"),
+    ("F8", b"\x1b[19~"),
+    ("F9", b"\x1b[20~"),
+    ("F10", b"\x1b[21~"),
+    ("F11", b"\x1b[23~"),
+    ("F12", b"\x1b[24~"),
+];
+
+fn lookup_named(name: &str) -> Option<&'static [u8]> {
+    NAMED_KEYS.iter().find(|(n, _)| *n == name).map(|(_, b)| *b)
+}
+
+fn try_split_chord(token: &str) -> Result<Option<(Vec<char>, &str)>, ParseError> {
+    if !token.contains('-') {
+        return Ok(None);
+    }
+    let parts: Vec<&str> = token.split('-').collect();
+    if parts.len() < 2 {
+        return Ok(None);
+    }
+    // First segment must look like a modifier; otherwise the token is just
+    // a literal that happens to contain '-' (e.g. "long-name").
+    if !is_modifier(parts[0]) {
+        return Ok(None);
+    }
+    let mut mods = Vec::with_capacity(parts.len() - 1);
+    for &m in &parts[..parts.len() - 1] {
+        if m.is_empty() {
+            return Err(err("malformed chord (empty modifier)"));
+        }
+        if !is_modifier(m) {
+            return Err(err(format!("unknown modifier '{m}'")));
+        }
+        mods.push(m.chars().next().expect("non-empty mod"));
+    }
+    let atom = *parts.last().expect("parts.len() >= 2");
+    if atom.is_empty() {
+        return Err(err("incomplete chord (no atom)"));
+    }
+    Ok(Some((mods, atom)))
+}
+
+fn is_modifier(s: &str) -> bool {
+    matches!(s, "C" | "M" | "S")
+}
+
+fn emit_chord(mods: &[char], atom: &str, out: &mut Vec<u8>) -> Result<(), ParseError> {
+    let has_alt = mods.contains(&'M');
+    let has_ctrl = mods.contains(&'C');
+    let has_shift = mods.contains(&'S');
+
+    if let Some(named_bytes) = lookup_named(atom) {
+        match (atom, has_shift, has_ctrl, has_alt) {
+            ("Tab", true, false, false) => {
+                // xterm shifted Tab (Back-Tab).
+                out.extend_from_slice(b"\x1b[Z");
+            }
+            (_, false, false, true) => {
+                // Alt-prefixed Named (e.g. M-Up): ESC then the Named bytes.
+                out.push(0x1b);
+                out.extend_from_slice(named_bytes);
+            }
+            (_, false, false, false) => out.extend_from_slice(named_bytes),
+            _ => {
+                return Err(err(format!("unsupported modifier on named key '{atom}'")));
+            }
+        }
+        return Ok(());
+    }
+
+    let mut chars = atom.chars();
+    let c = chars.next().ok_or_else(|| err("empty chord atom"))?;
+    if chars.next().is_some() {
+        return Err(err(format!(
+            "modifier prefix valid on single-char atom or Named only; got '{atom}'"
+        )));
+    }
+    if !c.is_ascii() {
+        return Err(err(format!("non-ASCII atom in chord: '{c}'")));
+    }
+    let mut byte = c as u8;
+    if has_shift {
+        byte = byte.to_ascii_uppercase();
+    }
+    if has_ctrl {
+        byte &= 0x1f;
+    }
+    if has_alt {
+        out.push(0x1b);
+    }
+    out.push(byte);
+    Ok(())
+}
+
+fn err(msg: impl Into<String>) -> ParseError {
+    ParseError { msg: msg.into() }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn t(s: &str) -> String {
+        s.to_string()
+    }
+
+    fn compile(strs: &[&str]) -> Result<Vec<u8>, ParseError> {
+        let toks: Vec<String> = strs.iter().map(|s| t(s)).collect();
+        compile_to_bytes(&toks)
+    }
+
+    #[test]
+    fn literal_single_char() {
+        assert_eq!(compile(&["a"]).unwrap(), b"a");
+    }
+
+    #[test]
+    fn ctrl_letter_collapses_to_control_code() {
+        assert_eq!(compile(&["C-a"]).unwrap(), &[0x01]);
+        assert_eq!(compile(&["C-c"]).unwrap(), &[0x03]);
+        assert_eq!(compile(&["C-l"]).unwrap(), &[0x0c]);
+    }
+
+    #[test]
+    fn ctrl_alt_letter_uses_esc_prefix() {
+        // SPEC §4.2 row: C-M-x → 0x1b 0x18
+        assert_eq!(compile(&["C-M-x"]).unwrap(), &[0x1b, 0x18]);
+    }
+
+    #[test]
+    fn named_keys_round_trip_table() {
+        // Spot-check every documented Named key.
+        let pairs: &[(&str, &[u8])] = &[
+            ("Enter", b"\r"),
+            ("Tab", b"\t"),
+            ("Esc", b"\x1b"),
+            ("Space", b" "),
+            ("Backspace", b"\x7f"),
+            ("Delete", b"\x1b[3~"),
+            ("Up", b"\x1b[A"),
+            ("Down", b"\x1b[B"),
+            ("Left", b"\x1b[D"),
+            ("Right", b"\x1b[C"),
+            ("Home", b"\x1b[H"),
+            ("End", b"\x1b[F"),
+            ("PageUp", b"\x1b[5~"),
+            ("PageDown", b"\x1b[6~"),
+            ("F1", b"\x1bOP"),
+            ("F4", b"\x1bOS"),
+            ("F5", b"\x1b[15~"),
+            ("F12", b"\x1b[24~"),
+        ];
+        for (name, want) in pairs {
+            let got = compile(&[name]).unwrap();
+            assert_eq!(&got, want, "mismatch on Named '{name}'");
+        }
+    }
+
+    #[test]
+    fn multi_token_concat_no_separator() {
+        // SPEC §4.4: 'echo' Space 'hi' Enter → b"echo hi\r"
+        assert_eq!(
+            compile(&["echo", "Space", "hi", "Enter"]).unwrap(),
+            b"echo hi\r"
+        );
+    }
+
+    #[test]
+    fn multi_char_token_is_literal() {
+        assert_eq!(compile(&["echo hi"]).unwrap(), b"echo hi");
+    }
+
+    #[test]
+    fn shift_tab_is_back_tab() {
+        assert_eq!(compile(&["S-Tab"]).unwrap(), b"\x1b[Z");
+    }
+
+    #[test]
+    fn alt_named_uses_esc_prefix() {
+        let got = compile(&["M-Up"]).unwrap();
+        assert_eq!(got, b"\x1b\x1b[A", "M-Up = ESC + Up");
+    }
+
+    #[test]
+    fn token_with_dash_but_no_modifier_is_literal() {
+        // "long-name" must NOT be parsed as chord — first segment "long" is
+        // not a Modifier, so the entire token is literal text.
+        assert_eq!(compile(&["long-name"]).unwrap(), b"long-name");
+    }
+
+    #[test]
+    fn rejects_unknown_modifier() {
+        // First segment 'X' is not a Modifier and the token contains '-',
+        // so this falls through to literal text — no error, just bytes.
+        // The actual reject case is when a *valid* modifier is followed by
+        // an unknown one mid-token. Asserted in the next test.
+        assert_eq!(compile(&["X-a"]).unwrap(), b"X-a");
+    }
+
+    #[test]
+    fn rejects_unknown_modifier_after_valid_one() {
+        let e = compile(&["C-X-y"]).unwrap_err();
+        assert!(e.to_string().contains("unknown modifier 'X'"), "got: {e}");
+    }
+
+    #[test]
+    fn rejects_empty_modifier_segment() {
+        let e = compile(&["C--a"]).unwrap_err();
+        assert!(e.to_string().contains("empty modifier"), "got: {e}");
+    }
+
+    #[test]
+    fn rejects_chord_without_atom() {
+        let e = compile(&["C-"]).unwrap_err();
+        assert!(e.to_string().contains("incomplete chord"), "got: {e}");
+    }
+
+    #[test]
+    fn rejects_empty_token() {
+        let e = compile(&[""]).unwrap_err();
+        assert!(e.to_string().contains("empty chord"), "got: {e}");
+    }
+
+    #[test]
+    fn rejects_newline_in_token() {
+        let e = compile(&["abc\ndef"]).unwrap_err();
+        assert!(e.to_string().contains("newline"), "got: {e}");
+    }
+
+    #[test]
+    fn rejects_empty_input() {
+        let toks: Vec<String> = vec![];
+        let e = compile_to_bytes(&toks).unwrap_err();
+        assert!(e.to_string().contains("no keys"), "got: {e}");
+    }
+
+    #[test]
+    fn is_named_key_recognises_table_entries() {
+        assert!(is_named_key("Enter"));
+        assert!(is_named_key("F12"));
+        assert!(!is_named_key("enter")); // case-sensitive
+        assert!(!is_named_key("hello"));
+    }
+
+    #[test]
+    fn rejects_unsupported_named_modifier_combo() {
+        // C-Enter is ambiguous across terminals; we surface a clear error
+        // rather than emit an arbitrary encoding.
+        let e = compile(&["C-Enter"]).unwrap_err();
+        assert!(
+            e.to_string().contains("unsupported modifier on named key"),
+            "got: {e}"
+        );
+    }
+}

--- a/src/keymap/mod.rs
+++ b/src/keymap/mod.rs
@@ -1,0 +1,8 @@
+//! Key-spec parsing & key-table dispatch helpers.
+//!
+//! Currently this module owns just the `keyspec` parser used by SPEC 06
+//! `send-keys`. SPEC 09 (custom keymap TOML) will share the same `keyspec`
+//! grammar — keep the parser self-contained so both consumers route
+//! through one canonical implementation.
+
+pub mod keyspec;

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ mod copy_mode;
 mod daemon;
 mod direct;
 mod ipc;
+mod keymap;
 mod layout;
 mod pane;
 mod project;

--- a/tests/send_keys.rs
+++ b/tests/send_keys.rs
@@ -1,0 +1,154 @@
+//! SPEC 06 — `ezpn-ctl send-keys` end-to-end coverage.
+//!
+//! Spawns a real `ezpn --server` daemon, connects to its JSON-IPC socket,
+//! and walks through the load-bearing `send-keys` semantics:
+//! - happy path: List → grab a pane id → SendKeys with a chord list
+//! - target=current: omitting the pane id resolves to the active pane
+//! - error path: pane-not-found
+//! - error path: --literal forbids named keys
+//!
+//! Wire-format layer is exercised inline so wire drift surfaces here even
+//! when the in-process serde tests stay green.
+
+mod common;
+
+use common::*;
+use std::io::{BufRead, BufReader, Write};
+use std::os::unix::net::UnixStream;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+/// Same scheme as `ipc::socket_path_for_pid` — duplicated here to keep the
+/// test crate decoupled from internal modules.
+fn ipc_socket_path(runtime: &Path, pid: u32) -> PathBuf {
+    runtime.join(format!("ezpn-{pid}.sock"))
+}
+
+/// Wait up to 3 s for the IPC socket to appear (separate from the
+/// per-session protocol socket that `spawn_test_daemon` already polls).
+fn wait_for_ipc_socket(path: &Path) {
+    let deadline = std::time::Instant::now() + Duration::from_secs(3);
+    while std::time::Instant::now() < deadline {
+        if path.exists() && UnixStream::connect(path).is_ok() {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    panic!("ipc socket {} never appeared", path.display());
+}
+
+/// Send one IPC request (JSON line) and read one response (JSON line).
+fn ipc_call(socket: &Path, request_json: &str) -> serde_json::Value {
+    let mut stream = UnixStream::connect(socket).expect("connect ipc socket");
+    stream
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .unwrap();
+    writeln!(stream, "{request_json}").expect("write ipc request");
+    stream.flush().unwrap();
+    let mut reader = BufReader::new(stream);
+    let mut line = String::new();
+    reader.read_line(&mut line).expect("read ipc response");
+    serde_json::from_str(line.trim()).expect("parse ipc response json")
+}
+
+#[test]
+fn send_keys_to_existing_pane_succeeds() {
+    let daemon = spawn_test_daemon("sk-ok");
+    let ipc_sock = ipc_socket_path(&daemon.runtime, daemon.pid());
+    wait_for_ipc_socket(&ipc_sock);
+
+    // 1. List panes — daemon bootstraps with at least one.
+    let listed = ipc_call(&ipc_sock, r#"{"cmd":"list"}"#);
+    let panes = listed["panes"]
+        .as_array()
+        .expect("list returns panes array");
+    assert!(!panes.is_empty(), "daemon must boot with at least one pane");
+    let pane_id = panes[0]["id"].as_u64().expect("pane id is u64") as usize;
+
+    // 2. SendKeys with a valid chord list — expect ok=true and a byte count.
+    let req = format!(
+        r#"{{"cmd":"send_keys","target":{{"kind":"id","value":{pane_id}}},"keys":["echo","Space","SENDKEYS_OK","Enter"],"literal":false}}"#
+    );
+    let resp = ipc_call(&ipc_sock, &req);
+    assert_eq!(
+        resp["ok"].as_bool(),
+        Some(true),
+        "send-keys must succeed: {resp}"
+    );
+    let msg = resp["message"].as_str().unwrap_or("");
+    assert!(
+        msg.starts_with("sent ") && msg.ends_with(" bytes"),
+        "expected 'sent N bytes', got {msg:?}"
+    );
+}
+
+#[test]
+fn send_keys_target_current_resolves_active_pane() {
+    let daemon = spawn_test_daemon("sk-cur");
+    let ipc_sock = ipc_socket_path(&daemon.runtime, daemon.pid());
+    wait_for_ipc_socket(&ipc_sock);
+
+    let resp = ipc_call(
+        &ipc_sock,
+        r#"{"cmd":"send_keys","target":{"kind":"current"},"keys":["a"],"literal":false}"#,
+    );
+    assert_eq!(
+        resp["ok"].as_bool(),
+        Some(true),
+        "current target must resolve: {resp}"
+    );
+}
+
+#[test]
+fn send_keys_unknown_pane_returns_structured_error() {
+    let daemon = spawn_test_daemon("sk-bad");
+    let ipc_sock = ipc_socket_path(&daemon.runtime, daemon.pid());
+    wait_for_ipc_socket(&ipc_sock);
+
+    let resp = ipc_call(
+        &ipc_sock,
+        r#"{"cmd":"send_keys","target":{"kind":"id","value":99999},"keys":["a"],"literal":false}"#,
+    );
+    assert_eq!(resp["ok"].as_bool(), Some(false));
+    let err = resp["error"].as_str().unwrap_or("");
+    assert!(
+        err.contains("pane 99999 not found"),
+        "expected 'pane 99999 not found', got {err:?}"
+    );
+}
+
+#[test]
+fn send_keys_literal_rejects_named_token() {
+    // Short prefix because macOS sun_path is capped at ~104 bytes — the
+    // tempdir prefix plus `ezpn-session-<prefix>-<pid>-<n>.sock` overflows
+    // with longer names.
+    let daemon = spawn_test_daemon("sk-lit");
+    let ipc_sock = ipc_socket_path(&daemon.runtime, daemon.pid());
+    wait_for_ipc_socket(&ipc_sock);
+
+    let resp = ipc_call(
+        &ipc_sock,
+        r#"{"cmd":"send_keys","target":{"kind":"current"},"keys":["Enter"],"literal":true}"#,
+    );
+    assert_eq!(resp["ok"].as_bool(), Some(false));
+    let err = resp["error"].as_str().unwrap_or("");
+    assert!(
+        err.contains("--literal forbids named keys"),
+        "expected 'literal forbids named keys', got {err:?}"
+    );
+}
+
+#[test]
+fn send_keys_empty_payload_rejected() {
+    let daemon = spawn_test_daemon("sk-emp");
+    let ipc_sock = ipc_socket_path(&daemon.runtime, daemon.pid());
+    wait_for_ipc_socket(&ipc_sock);
+
+    let resp = ipc_call(
+        &ipc_sock,
+        r#"{"cmd":"send_keys","target":{"kind":"current"},"keys":[],"literal":false}"#,
+    );
+    assert_eq!(resp["ok"].as_bool(), Some(false));
+    let err = resp["error"].as_str().unwrap_or("");
+    assert!(err.contains("no keys"), "expected 'no keys', got {err:?}");
+}


### PR DESCRIPTION
## Summary

[SPEC 06](https://github.com/subinium/ezpn/blob/main/docs/spec/v0.10.0/06-send-keys-api.md) — the load-bearing primitive for any non-human pane driver (editors, AI agents, CI scripts).

- **`IpcRequest::SendKeys`** + `PaneTarget = Id { value } | Current`
- **`src/keymap/keyspec.rs`** — chord/modifier grammar (`C-`, `M-`, `S-`) with the standard Named keys (Enter, Tab, Esc, Space, Backspace, Delete, arrows, Home/End, PageUp/PageDown, F1–F12)
- **`ezpn-ctl send-keys [--pane N | --target current] [--literal] -- <key>...`** — git-style mandatory `--` separator, structured errors mapped to non-zero exits
- **App-side dispatcher** routes through `Pane::write_bytes`, enforces SPEC §4.5's `--literal forbids named keys` guard, reports `sent N bytes` on success

## Wire-format note

SPEC §4.1 shows `keys: String` in the draft JSON example; this PR uses **`keys: Vec<String>`** so multi-char literal arguments like `'echo hi'` round-trip without escape ambiguity. Documented inline at `src/keymap/keyspec.rs`. No protocol bump (`PROTOCOL_VERSION` unchanged).

## Test plan

- [x] **18 keyspec parser tests** — Named-key byte table (SPEC §4.2), Ctrl-letter (`C-a` → 0x01), Ctrl+Alt-letter (`C-M-x` → ESC + 0x18), Shift-Tab back-tab, M-Up Alt-prefix, multi-token concat (`'echo' Space 'hi' Enter` → `b"echo hi\r"`)
- [x] **Reject set** — empty chord, embedded newline, unknown modifier mid-token (`C-X-y`), empty modifier (`C--a`), no atom (`C-`), unsupported Named modifier (`C-Enter`)
- [x] **5 integration tests in `tests/send_keys.rs`** — happy path with `List`-then-`SendKeys`, `target=current`, pane-not-found error, `--literal` named-key reject, empty-payload reject (each spawns a real `ezpn --server`)
- [x] **211 tests total pass** (was 162: +18 keyspec + +5 integration + others touching scope), `cargo clippy --all-targets -- -D warnings` clean

## Compatibility

- **Wire protocol**: unchanged (still v1).
- **JSON IPC**: additive variants only (`SendKeys`, `PaneTarget`); old daemons reject the new variant with the existing `invalid request: …` path.
- **CLI**: new `send-keys` subcommand only; existing commands unchanged.

## Out of scope (documented in SPEC §3)

- Cross-session targeting (deferred to v0.11 multi-session model)
- Recording / playback (`tmux capture-keys`)
- Macros / async queueing / chord-with-timeout

Closes #38